### PR TITLE
Log ocamlmerlin stderr output to console, only try running dependency…

### DIFF
--- a/src/server/processes/merlin.ts
+++ b/src/server/processes/merlin.ts
@@ -27,6 +27,7 @@ export default class Merlin implements rpc.Disposable {
   public initialize(): void {
     const ocamlmerlin = this.session.settings.reason.path.ocamlmerlin;
     this.process = this.session.environment.spawn(ocamlmerlin);
+
     this.process.on("error", (error: Error & { code: string }) => {
       if (error.code === "ENOENT") {
         const msg = `Cannot find merlin binary at "${ocamlmerlin}".`;
@@ -36,6 +37,11 @@ export default class Merlin implements rpc.Disposable {
         throw error;
      }
     });
+
+    this.process.stderr.on("data", (data: string) => {
+      this.session.connection.window.showErrorMessage(`ocamlmerlin error: ${data}`);
+    });
+
     this.readline = readline.createInterface({
       input: this.process.stdout,
       output: this.process.stdin,

--- a/src/server/session/environment.ts
+++ b/src/server/session/environment.ts
@@ -1,6 +1,5 @@
 import { ChildProcess, SpawnOptions } from "child_process";
 import * as childProcess from "child_process";
-import * as fs from "fs";
 import * as path from "path";
 import * as URL from "url";
 import * as rpc from "vscode-jsonrpc";
@@ -57,15 +56,10 @@ export default class Environment implements rpc.Disposable {
   }
 
   private async detectDependencyEnv(): Promise<void> {
-    const pkgPath = `${this.workspaceRoot()}/package.json`;
     try {
-      let hasDependencyEnv = true;
-      const pkg: any = await new Promise((res, rej) => fs.readFile(pkgPath, (err, data) => err ? rej(err) : res(JSON.parse(data.toString()))));
-      // tslint:disable
-      hasDependencyEnv = hasDependencyEnv && pkg["dependencies"] != null;
-      hasDependencyEnv = hasDependencyEnv && pkg["dependencies"]["dependency-env"] != null;
-      // tslint:enable
-      (this as any).preamble = `eval $(${this.session.environment.workspaceRoot()}/node_modules/.bin/dependencyEnv) && `;
+      // Add preamble to run dependencyEnv, but only if it exists
+      const dependencyEnvScript = `${this.session.environment.workspaceRoot()}/node_modules/.bin/dependencyEnv`;
+      (this as any).preamble = `[ ! -f ${dependencyEnvScript} ] || eval $(${dependencyEnvScript}) && `;
     } catch (err) {
       //
     }


### PR DESCRIPTION
This fixes a couple of issues I had while getting vscode-reasonml working:
1. Previously, ocamlmerlin errors printed to stderr were ignored. Now if an error occurs, the error message will be shown. (I think this at least partially fixes freebroccolo/vscode-reasonml#39?)
2. The ocamlmerlin call would fail if dependency-env was not installed