### PR TITLE
Add support for other editors

### DIFF
--- a/src/server/command/getPrefix.ts
+++ b/src/server/command/getPrefix.ts
@@ -1,7 +1,17 @@
 import * as server from "vscode-languageserver";
-import { remote } from "../../shared";
 import Session from "../session";
 
 export default async function(session: Session, event: server.TextDocumentPositionParams): Promise<null | string> {
-  return session.connection.sendRequest<null | string>(remote.client.givePrefix.method, event);
+  const document = session.synchronizer.getTextDocument(event.textDocument.uri);
+  if (!document) {
+    return null;
+  }
+  const startPosition = {
+    character: 0,
+    line: event.position.line,
+  };
+  const endPosition = event.position;
+  const startOffset = document.offsetAt(startPosition);
+  const endOffset = document.offsetAt(endPosition);
+  return document.getText().substring(startOffset, endOffset);
 }

--- a/src/server/command/getText.ts
+++ b/src/server/command/getText.ts
@@ -1,6 +1,11 @@
-import { remote, types } from "../../shared";
+import { types } from "../../shared";
 import Session from "../session";
 
-export default async function(session: Session, event: types.Location): Promise<string> {
-  return session.connection.sendRequest<string>(remote.client.giveText.method, event);
+export default async function(session: Session, event: types.Location): Promise<string | undefined> {
+  const textDocument = session.synchronizer.getTextDocument(event.uri);
+  if (textDocument) {
+    return textDocument.getText();
+  } else {
+    return undefined;
+  }
 }

--- a/src/server/command/getTextDocument.ts
+++ b/src/server/command/getTextDocument.ts
@@ -1,7 +1,6 @@
-import { remote, types } from "../../shared";
+import { types } from "../../shared";
 import Session from "../session";
 
-export default async function(session: Session, event: types.TextDocumentIdentifier): Promise<types.TextDocument> {
-  const data = await session.connection.sendRequest<types.TextDocumentData>(remote.client.giveTextDocument.method, event);
-  return types.TextDocument.create(event.uri, data.languageId, data.version, data.content);
+export default async function(session: Session, event: types.TextDocumentIdentifier): Promise<types.TextDocument | undefined> {
+  return session.synchronizer.getTextDocument(event.uri);
 }

--- a/src/server/command/getWordAtPosition.ts
+++ b/src/server/command/getWordAtPosition.ts
@@ -1,6 +1,25 @@
-import { remote, types } from "../../shared";
+import { types } from "../../shared";
 import Session from "../session";
 
+function isWhitespace(str: string): boolean {
+  return str.trim() === str;
+}
+
 export default async function(session: Session, event: types.ILocatedPosition): Promise<string> {
-  return session.connection.sendRequest<string>(remote.client.giveWordAtPosition.method, event);
+  const textDocument = session.synchronizer.getTextDocument(event.uri);
+  if (!textDocument) {
+    return "";
+  }
+
+  const text = textDocument.getText();
+  const offset = textDocument.offsetAt(event.position);
+  let startIndex = offset;
+  while (startIndex >= 0 && !isWhitespace(text[startIndex])) {
+    startIndex--;
+  }
+  let endIndex = offset;
+  while (endIndex < text.length && !isWhitespace(text[endIndex])) {
+    endIndex++;
+  }
+  return text.substring(startIndex, endIndex);
 }

--- a/src/server/feature/codeLens.ts
+++ b/src/server/feature/codeLens.ts
@@ -28,6 +28,7 @@ export default function(session: Session): server.RequestHandler<server.CodeLens
 
     if (response.class !== "return") return []; // new rpc.ResponseError(-1, "onCodeLens: failed", undefined);
     const textDoc = await command.getTextDocument(session, textDocument);
+    if (!textDoc) return [];
     if (token.isCancellationRequested) return [];
 
     const symbols = merlin.Outline.intoCode(response.value, textDocument);

--- a/src/server/feature/documentFormatting.ts
+++ b/src/server/feature/documentFormatting.ts
@@ -6,6 +6,7 @@ import Session from "../session";
 export default function(session: Session): server.RequestHandler<server.DocumentFormattingParams, types.TextEdit[], void> {
   return async (event, token) => {
     const itxt = await command.getTextDocument(session, event.textDocument);
+    if (itxt == null) return [];
     const idoc = types.TextDocument.create(event.textDocument.uri, itxt.languageId, itxt.version, itxt.getText());
     if (token.isCancellationRequested) return [];
     let otxt : null | string = null;

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -46,7 +46,9 @@ export default class Analyzer implements rpc.Disposable {
     return async (id) => {
       if (syncKind === server.TextDocumentSyncKind.Full) {
         const document = await command.getTextDocument(this.session, id);
-        await this.session.merlin.sync(merlin.Sync.tell("start", "end", document.getText()), id);
+        if (document) {
+          await this.session.merlin.sync(merlin.Sync.tell("start", "end", document.getText()), id);
+        }
       }
       const errors = await this.session.merlin.query(merlin.Query.errors(), id);
       if (errors.class !== "return") return;

--- a/src/server/session/indexer.ts
+++ b/src/server/session/indexer.ts
@@ -60,8 +60,10 @@ export default class Indexer implements rpc.Disposable {
       for (const id of modules) {
         if (/\.(ml|re)i$/.test(id.uri)) continue;
         const document = await command.getTextDocument(this.session, id);
-        await this.session.merlin.sync(merlin.Sync.tell("start", "end", document.getText()), id);
-        await this.refreshSymbols(id);
+        if (document) {
+          await this.session.merlin.sync(merlin.Sync.tell("start", "end", document.getText()), id);
+          await this.refreshSymbols(id);
+        }
       }
     }
   }

--- a/src/shared/merlin/data.ts
+++ b/src/shared/merlin/data.ts
@@ -1,6 +1,5 @@
 import * as types from "vscode-languageserver-types";
 import * as ordinal from "./ordinal";
-import * as remote from "../remote";
 
 export namespace Case {
   export type Destruct = [{ end: ordinal.ColumnLine; start: ordinal.ColumnLine }, string];
@@ -89,11 +88,10 @@ export namespace ErrorReport {
       }
     }
   }
-  async function improveMessage(session: any, { uri, range  }: types.Location, original: string): Promise<string> {
+  async function improveMessage(session: any, { uri }: types.Location, original: string): Promise<string> {
     if (original === "Invalid statement") {
-      const location = types.Location.create(uri, range);
-      const text = await session.connection.sendRequest(remote.client.giveText, location);
-      if (text === "=") {
+      const document = session.synchronizer.getText(uri);
+      if (document && document.getText() === "=") {
         return "Functions must be defined with => instead of the = symbol.";
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,11 +25,7 @@
   version "2.0.29"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-2.0.29.tgz#5002e14f75e2d71e564281df0431c8c1b4a2a36a"
 
-"@types/node@*":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.5.tgz#96a0f0a618b7b606f1ec547403c00650210bfbb7"
-
-"@types/node@7.0.22":
+"@types/node@*", "@types/node@7.0.22":
   version "7.0.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.22.tgz#4593f4d828bdd612929478ea40c67b4f403ca255"
 


### PR DESCRIPTION
Right now, the language server makes an RPC call to get the contents of
the buffers open in the editor when it needs to access them. This
doesn't work with servers that don't happen to be running the VS Code
plugin.

The standard way to do this is for the language server to keep a copy of
all the open files in memory and refer to that when necessary. This
commit does this, which allows it to work in Facebook's Nuclide, and no
doubt other editors in due time.

I tested it in Nuclide and got things like types on hover to show up in
an OCaml source files, which didn't work before this commit.