### PR TITLE
Fix autocomplete

### DIFF
--- a/src/server/command/getPrefix.ts
+++ b/src/server/command/getPrefix.ts
@@ -13,5 +13,9 @@ export default async function(session: Session, event: server.TextDocumentPositi
   const endPosition = event.position;
   const startOffset = document.offsetAt(startPosition);
   const endOffset = document.offsetAt(endPosition);
-  return document.getText().substring(startOffset, endOffset);
+  const lineContent = document.getText().substring(startOffset, endOffset);
+
+  const pattern = /[A-Za-z_][A-Za-z_'0-9]*(?:\.[A-Za-z_][A-Za-z_'0-9]*)*\.?$/;
+  const match = pattern.exec(lineContent);
+  return match ? match[0] : null;
 }


### PR DESCRIPTION
Autocomplete wasn't working in Nuclide before I added support for other
editors, so I wasn't confused when it wasn't working afterwards. I
completely misinterpreted what `getPrefix` was supposed to do and just
returned from the entire beginning of the line, but really we only want
from the beginning of this expression. Autocomplete actually works in
Nuclide now (and should probably not be broken in other editors, but I
didn't figure out how to test the extension in VS Code).