### PR TITLE
Fix #22 - Handle case when `range` is omitted for textDocument/didChange event

### DIFF
--- a/src/server/session/synchronizer.ts
+++ b/src/server/session/synchronizer.ts
@@ -36,15 +36,12 @@ export default class Synchronizer implements rpc.Disposable {
 
         this.session.connection.onDidChangeTextDocument(async (event): Promise<void> => {
             for (const change of event.contentChanges) {
-                if (!change) {
-                    continue;
-                }
+
+                if (!change) continue;
 
                 const oldDocument = this.textDocuments.get(event.textDocument.uri);
 
-                if (!oldDocument) {
-                    continue;
-                }
+                if (!oldDocument) continue;
 
                 if (!change.range) {
                     await this.doFullSync(event.textDocument, oldDocument.languageId, change.text);
@@ -88,9 +85,7 @@ export default class Synchronizer implements rpc.Disposable {
     }
 
     private async doIncrementalSync(oldDocument: types.TextDocument, newDocument: types.VersionedTextDocumentIdentifier, change: TextDocumentContentChangeEvent): Promise<void> {
-        if (!change || !change.range) {
-            return;
-        }
+        if (!change || !change.range) return;
 
         const newContent = this.applyChangesToTextDocumentContent(oldDocument, change);
         if (null != newContent) {

--- a/src/server/session/synchronizer.ts
+++ b/src/server/session/synchronizer.ts
@@ -4,114 +4,114 @@ import { TextDocumentContentChangeEvent } from "../../shared/types";
 import Session from "./index";
 
 export default class Synchronizer implements rpc.Disposable {
-    private session: Session;
-    private textDocuments: Map<string, types.TextDocument> = new Map();
+  private session: Session;
+  private textDocuments: Map<string, types.TextDocument> = new Map();
 
-    constructor(session: Session) {
-        this.session = session;
-        return this;
-    }
+  constructor(session: Session) {
+    this.session = session;
+    return this;
+  }
 
-    public dispose(): void {
-        return;
-    }
+  public dispose(): void {
+    return;
+  }
 
-    public async initialize(): Promise<void> {
-        return;
-    }
+  public async initialize(): Promise<void> {
+    return;
+  }
 
-    public listen(): void {
-        this.session.connection.onDidCloseTextDocument((event) => {
-            this.textDocuments.delete(event.textDocument.uri);
-            this.session.analyzer.clear(event.textDocument);
-        });
+  public listen(): void {
+    this.session.connection.onDidCloseTextDocument((event) => {
+      this.textDocuments.delete(event.textDocument.uri);
+      this.session.analyzer.clear(event.textDocument);
+    });
 
-        this.session.connection.onDidOpenTextDocument(async (event): Promise<void> => {
-            await this.doFullSync(event.textDocument, event.textDocument.languageId, event.textDocument.text);
-            this.session.analyzer.refreshImmediate(event.textDocument);
-            // this.session.indexer.refreshSymbols(event.textDocument);
-            await this.session.indexer.populate(event.textDocument);
-            // this.session.analyzer.refreshWorkspace(event.textDocument);
-        });
+    this.session.connection.onDidOpenTextDocument(async (event): Promise<void> => {
+      await this.doFullSync(event.textDocument, event.textDocument.languageId, event.textDocument.text);
+      this.session.analyzer.refreshImmediate(event.textDocument);
+      // this.session.indexer.refreshSymbols(event.textDocument);
+      await this.session.indexer.populate(event.textDocument);
+      // this.session.analyzer.refreshWorkspace(event.textDocument);
+    });
 
-        this.session.connection.onDidChangeTextDocument(async (event): Promise<void> => {
-            for (const change of event.contentChanges) {
+    this.session.connection.onDidChangeTextDocument(async (event): Promise<void> => {
+      for (const change of event.contentChanges) {
 
-                if (!change) continue;
+        if (!change) continue;
 
-                const oldDocument = this.textDocuments.get(event.textDocument.uri);
+        const oldDocument = this.textDocuments.get(event.textDocument.uri);
 
-                if (!oldDocument) continue;
+        if (!oldDocument) continue;
 
-                if (!change.range) {
-                    await this.doFullSync(event.textDocument, oldDocument.languageId, change.text);
-                } else {
-                    await this.doIncrementalSync(oldDocument, event.textDocument, change);
-                }
-
-                this.session.analyzer.refreshDebounced(event.textDocument);
-            }
-        });
-
-        this.session.connection.onDidSaveTextDocument(async (event): Promise<void> => {
-            this.session.analyzer.refreshImmediate(event.textDocument);
-            // this.session.analyzer.refreshWorkspace(event.textDocument);
-        });
-    }
-
-    public onDidChangeConfiguration(): void {
-        return;
-    }
-
-    public getTextDocument(uri: string): null | types.TextDocument {
-        const document = this.textDocuments.get(uri);
-        if (null == document) return null;
-        return document;
-    }
-
-    private async doFullSync(textDocument: types.VersionedTextDocumentIdentifier, languageId: string, content: string): Promise<void> {
-        this.textDocuments.set(
-            textDocument.uri,
-            types.TextDocument.create(
-                textDocument.uri,
-                languageId,
-                textDocument.version,
-                content
-            ),
-        );
-
-        const request = merlin.Sync.tell("start", "end", content);
-        await this.session.merlin.sync(request, textDocument, Infinity);
-    }
-
-    private async doIncrementalSync(oldDocument: types.TextDocument, newDocument: types.VersionedTextDocumentIdentifier, change: TextDocumentContentChangeEvent): Promise<void> {
-        if (!change || !change.range) return;
-
-        const newContent = this.applyChangesToTextDocumentContent(oldDocument, change);
-        if (null != newContent) {
-            this.textDocuments.set(
-                newDocument.uri,
-                types.TextDocument.create(
-                    oldDocument.uri,
-                    oldDocument.languageId,
-                    newDocument.version,
-                    newContent,
-                ),
-            );
+        if (!change.range) {
+          await this.doFullSync(event.textDocument, oldDocument.languageId, change.text);
+        } else {
+          await this.doIncrementalSync(oldDocument, event.textDocument, change);
         }
 
-        const startPos = merlin.Position.fromCode(change.range.start);
-        const endPos = merlin.Position.fromCode(change.range.end);
-        const request = merlin.Sync.tell(startPos, endPos, change.text);
-        await this.session.merlin.sync(request, newDocument, Infinity);
+        this.session.analyzer.refreshDebounced(event.textDocument);
+      }
+    });
+
+    this.session.connection.onDidSaveTextDocument(async (event): Promise<void> => {
+      this.session.analyzer.refreshImmediate(event.textDocument);
+      // this.session.analyzer.refreshWorkspace(event.textDocument);
+    });
+  }
+
+  public onDidChangeConfiguration(): void {
+    return;
+  }
+
+  public getTextDocument(uri: string): null | types.TextDocument {
+    const document = this.textDocuments.get(uri);
+    if (null == document) return null;
+    return document;
+  }
+
+  private applyChangesToTextDocumentContent(oldDocument: types.TextDocument, change: TextDocumentContentChangeEvent): null | string {
+    if (null == change.range) return null;
+    const startOffset = oldDocument.offsetAt(change.range.start);
+    const endOffset = oldDocument.offsetAt(change.range.end);
+    const before = oldDocument.getText().substr(0, startOffset);
+    const after = oldDocument.getText().substr(endOffset);
+    return `${before}${change.text}${after}`;
+  }
+
+  private async doFullSync(textDocument: types.VersionedTextDocumentIdentifier, languageId: string, content: string): Promise<void> {
+    this.textDocuments.set(
+      textDocument.uri,
+      types.TextDocument.create(
+        textDocument.uri,
+        languageId,
+        textDocument.version,
+        content,
+      ),
+    );
+
+    const request = merlin.Sync.tell("start", "end", content);
+    await this.session.merlin.sync(request, textDocument, Infinity);
+  }
+
+  private async doIncrementalSync(oldDocument: types.TextDocument, newDocument: types.VersionedTextDocumentIdentifier, change: TextDocumentContentChangeEvent): Promise<void> {
+    if (!change || !change.range) return;
+
+    const newContent = this.applyChangesToTextDocumentContent(oldDocument, change);
+    if (null != newContent) {
+      this.textDocuments.set(
+        newDocument.uri,
+        types.TextDocument.create(
+          oldDocument.uri,
+          oldDocument.languageId,
+          newDocument.version,
+          newContent,
+        ),
+      );
     }
 
-    private applyChangesToTextDocumentContent(oldDocument: types.TextDocument, change: TextDocumentContentChangeEvent): null | string {
-        if (null == change.range) return null;
-        const startOffset = oldDocument.offsetAt(change.range.start);
-        const endOffset = oldDocument.offsetAt(change.range.end);
-        const before = oldDocument.getText().substr(0, startOffset);
-        const after = oldDocument.getText().substr(endOffset);
-        return `${before}${change.text}${after}`;
-    }
+    const startPos = merlin.Position.fromCode(change.range.start);
+    const endPos = merlin.Position.fromCode(change.range.end);
+    const request = merlin.Sync.tell(startPos, endPos, change.text);
+    await this.session.merlin.sync(request, newDocument, Infinity);
+  }
 }

--- a/src/server/session/synchronizer.ts
+++ b/src/server/session/synchronizer.ts
@@ -4,96 +4,119 @@ import { TextDocumentContentChangeEvent } from "../../shared/types";
 import Session from "./index";
 
 export default class Synchronizer implements rpc.Disposable {
-  private session: Session;
-  private textDocuments: Map<string, types.TextDocument> = new Map();
+    private session: Session;
+    private textDocuments: Map<string, types.TextDocument> = new Map();
 
-  constructor(session: Session) {
-    this.session = session;
-    return this;
-  }
+    constructor(session: Session) {
+        this.session = session;
+        return this;
+    }
 
-  public dispose(): void {
-    return;
-  }
+    public dispose(): void {
+        return;
+    }
 
-  public async initialize(): Promise<void> {
-    return;
-  }
+    public async initialize(): Promise<void> {
+        return;
+    }
 
-  public listen(): void {
-    this.session.connection.onDidCloseTextDocument((event) => {
-      this.textDocuments.delete(event.textDocument.uri);
-      this.session.analyzer.clear(event.textDocument);
-    });
+    public listen(): void {
+        this.session.connection.onDidCloseTextDocument((event) => {
+            this.textDocuments.delete(event.textDocument.uri);
+            this.session.analyzer.clear(event.textDocument);
+        });
 
-    this.session.connection.onDidOpenTextDocument(async (event): Promise<void> => {
-      this.textDocuments.set(
-        event.textDocument.uri,
-        types.TextDocument.create(
-          event.textDocument.uri,
-          event.textDocument.languageId,
-          event.textDocument.version,
-          event.textDocument.text,
-        ),
-      );
-      const request = merlin.Sync.tell("start", "end", event.textDocument.text);
-      await this.session.merlin.sync(request, event.textDocument, Infinity);
-      this.session.analyzer.refreshImmediate(event.textDocument);
-      // this.session.indexer.refreshSymbols(event.textDocument);
-      await this.session.indexer.populate(event.textDocument);
-      // this.session.analyzer.refreshWorkspace(event.textDocument);
-    });
+        this.session.connection.onDidOpenTextDocument(async (event): Promise<void> => {
+            await this.doFullSync(event.textDocument, event.textDocument.languageId, event.textDocument.text);
+            this.session.analyzer.refreshImmediate(event.textDocument);
+            // this.session.indexer.refreshSymbols(event.textDocument);
+            await this.session.indexer.populate(event.textDocument);
+            // this.session.analyzer.refreshWorkspace(event.textDocument);
+        });
 
-    this.session.connection.onDidChangeTextDocument(async (event): Promise<void> => {
-      for (const change of event.contentChanges) {
-        if (change && change.range) {
-          const oldDocument = this.textDocuments.get(event.textDocument.uri);
-          if (null != oldDocument) {
-            const newContent = this.applyChangesToTextDocumentContent(oldDocument, change);
-            if (null != newContent) {
-              this.textDocuments.set(
-                event.textDocument.uri,
-                types.TextDocument.create(
-                  oldDocument.uri,
-                  oldDocument.languageId,
-                  event.textDocument.version,
-                  newContent,
-                ),
-              );
+        this.session.connection.onDidChangeTextDocument(async (event): Promise<void> => {
+            for (const change of event.contentChanges) {
+                if (!change) {
+                    continue;
+                }
+
+                const oldDocument = this.textDocuments.get(event.textDocument.uri);
+
+                if (!oldDocument) {
+                    continue;
+                }
+
+                if (!change.range) {
+                    await this.doFullSync(event.textDocument, oldDocument.languageId, change.text);
+                } else {
+                    await this.doIncrementalSync(oldDocument, event.textDocument, change);
+                }
+
+                this.session.analyzer.refreshDebounced(event.textDocument);
             }
-          }
+        });
 
-          const startPos = merlin.Position.fromCode(change.range.start);
-          const endPos = merlin.Position.fromCode(change.range.end);
-          const request = merlin.Sync.tell(startPos, endPos, change.text);
-          await this.session.merlin.sync(request, event.textDocument, Infinity);
+        this.session.connection.onDidSaveTextDocument(async (event): Promise<void> => {
+            this.session.analyzer.refreshImmediate(event.textDocument);
+            // this.session.analyzer.refreshWorkspace(event.textDocument);
+        });
+    }
+
+    public onDidChangeConfiguration(): void {
+        return;
+    }
+
+    public getTextDocument(uri: string): null | types.TextDocument {
+        const document = this.textDocuments.get(uri);
+        if (null == document) return null;
+        return document;
+    }
+
+    private async doFullSync(textDocument: types.VersionedTextDocumentIdentifier, languageId: string, content: string): Promise<void> {
+        this.textDocuments.set(
+            textDocument.uri,
+            types.TextDocument.create(
+                textDocument.uri,
+                languageId,
+                textDocument.version,
+                content
+            ),
+        );
+
+        const request = merlin.Sync.tell("start", "end", content);
+        await this.session.merlin.sync(request, textDocument, Infinity);
+    }
+
+    private async doIncrementalSync(oldDocument: types.TextDocument, newDocument: types.VersionedTextDocumentIdentifier, change: TextDocumentContentChangeEvent): Promise<void> {
+        if (!change || !change.range) {
+            return;
         }
-      }
-      this.session.analyzer.refreshDebounced(event.textDocument);
-    });
 
-    this.session.connection.onDidSaveTextDocument(async (event): Promise<void> => {
-      this.session.analyzer.refreshImmediate(event.textDocument);
-      // this.session.analyzer.refreshWorkspace(event.textDocument);
-    });
-  }
+        const newContent = this.applyChangesToTextDocumentContent(oldDocument, change);
+        if (null != newContent) {
+            this.textDocuments.set(
+                newDocument.uri,
+                types.TextDocument.create(
+                    oldDocument.uri,
+                    oldDocument.languageId,
+                    newDocument.version,
+                    newContent,
+                ),
+            );
+        }
 
-  public onDidChangeConfiguration(): void {
-    return;
-  }
+        const startPos = merlin.Position.fromCode(change.range.start);
+        const endPos = merlin.Position.fromCode(change.range.end);
+        const request = merlin.Sync.tell(startPos, endPos, change.text);
+        await this.session.merlin.sync(request, newDocument, Infinity);
+    }
 
-  public getTextDocument(uri: string): null | types.TextDocument {
-    const document = this.textDocuments.get(uri);
-    if (null == document) return null;
-    return document;
-  }
-
-  private applyChangesToTextDocumentContent(oldDocument: types.TextDocument, change: TextDocumentContentChangeEvent): null | string {
-    if (null == change.range) return null;
-    const startOffset = oldDocument.offsetAt(change.range.start);
-    const endOffset = oldDocument.offsetAt(change.range.end);
-    const before = oldDocument.getText().substr(0, startOffset);
-    const after = oldDocument.getText().substr(endOffset);
-    return `${before}${change.text}${after}`;
-  }
+    private applyChangesToTextDocumentContent(oldDocument: types.TextDocument, change: TextDocumentContentChangeEvent): null | string {
+        if (null == change.range) return null;
+        const startOffset = oldDocument.offsetAt(change.range.start);
+        const endOffset = oldDocument.offsetAt(change.range.end);
+        const before = oldDocument.getText().substr(0, startOffset);
+        const after = oldDocument.getText().substr(endOffset);
+        return `${before}${change.text}${after}`;
+    }
 }

--- a/src/server/session/synchronizer.ts
+++ b/src/server/session/synchronizer.ts
@@ -36,19 +36,14 @@ export default class Synchronizer implements rpc.Disposable {
 
     this.session.connection.onDidChangeTextDocument(async (event): Promise<void> => {
       for (const change of event.contentChanges) {
-
         if (!change) continue;
-
         const oldDocument = this.textDocuments.get(event.textDocument.uri);
-
         if (!oldDocument) continue;
-
         if (!change.range) {
           await this.doFullSync(event.textDocument, oldDocument.languageId, change.text);
         } else {
           await this.doIncrementalSync(oldDocument, event.textDocument, change);
         }
-
         this.session.analyzer.refreshDebounced(event.textDocument);
       }
     });


### PR DESCRIPTION
Fixes #22 by handling the case where `change.range` is not specified. According to the language server protocol spec, this should work by applying the `change.text` as the full set of document. This functionality is crucial for Oni as, in some cases, there is not a straightforward way to get a delta of text edits for normal mode operations - so we leverage this protocol to fully sync the document.

A couple of changes were made:
- Refactor the full-sync strategy used on open to a helper method, such that it can be re-used in the case where `change.range` is not specified, as a good chunk of the logic is the same.
- Refactor the incremental-sync strategy so that it'd be at the same level of abstraction
- Leverage either the incremental-sync or the full-sync strategy depending on whether `change.range` is specified.

@freebroccolo , please let me know if there are any concerns you have or changes you'd like me to make. Thanks for this server!