### PR TITLE
Launch ocamlmerlin in the project root

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "vscode-jsonrpc": "3.2.0",
     "vscode-languageclient": "3.2.2",
     "vscode-languageserver": "3.2.2",
-    "vscode-languageserver-types": "3.2.0"
+    "vscode-languageserver-types": "3.2.0",
+    "vscode-uri": "1.0.1"
   }
 }

--- a/src/server/processes/merlin.ts
+++ b/src/server/processes/merlin.ts
@@ -3,6 +3,7 @@ import * as childProcess from "child_process";
 import * as _ from "lodash";
 import * as readline from "readline";
 import * as rpc from "vscode-jsonrpc";
+import Uri from "vscode-uri";
 import { merlin, types } from "../../shared";
 import Session from "../session";
 
@@ -26,7 +27,9 @@ export default class Merlin implements rpc.Disposable {
 
   public initialize(): void {
     const ocamlmerlin = this.session.settings.reason.path.ocamlmerlin;
-    this.process = this.session.environment.spawn(ocamlmerlin);
+    const cwd = this.session.initConf.rootUri || this.session.initConf.rootPath;
+    const options = cwd ? { cwd: Uri.parse(cwd).fsPath } : {};
+    this.process = this.session.environment.spawn(ocamlmerlin, [], options);
 
     this.process.on("error", (error: Error & { code: string }) => {
       if (error.code === "ENOENT") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -243,6 +243,10 @@ vscode-languageserver@3.2.2:
     vscode-jsonrpc "^3.2.0"
     vscode-languageserver-types "^3.2.0"
 
+vscode-uri@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.1.tgz#11a86befeac3c4aa3ec08623651a3c81a6d0bbc8"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
Launching `ocamlmerlin` it wherever the language server is invoked
oftentimes works because the language server is usually invoked in the
project root, but that is not a guarantee.