### PR TITLE
Make `spawn` detect .cmd files on windows

### DIFF
--- a/src/server/session/environment.ts
+++ b/src/server/session/environment.ts
@@ -35,7 +35,11 @@ export default class Environment implements rpc.Disposable {
     return path.relative(rootPath, Environment.uriToPath(id));
   }
 
-  public spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess {
+  public spawn(command: string, args: string[] = [], options: SpawnOptions = {}): ChildProcess {
+    if (process.platform === 'win32') {
+      options.shell = true;
+    }
+
     return childProcess.spawn(command, args, options);
   }
 


### PR DESCRIPTION
npm installs `bin` files with `.cmd` extension on Windows. When I install https://github.com/fhelwanger/ocaml-on-windows, I get opam.cmd, ocamlmerlin.cmd, etc.

The problem is that child_process.spawn doesn't find .cmd files by default. This PR [adds `{shell: true}`](https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows) to spawn options to make it work on Windows by default. This way, users won't need to configure paths manually.