### PR TITLE
Integrate better errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,14 @@
   "version": "0.2.0",
   "configurations": [
     {
+			"name": "Attach to Server",
       "type": "node",
       "request": "attach",
-      "name": "Attach to Process",
-      "outDir": "${workspaceRoot}/out/src",
-      "port": 6004,
-      "sourceMaps": true
+			"port": 6004,
+      "sourceMaps": true,
+  		"outFiles": [
+				"${workspaceRoot}/out/src/**/*.js"
+			]
     },
     {
       "type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Attach to Server",
+      "name": "Attach to Process",
       "type": "node",
       "request": "attach",
       "port": 6004,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,14 @@
   "version": "0.2.0",
   "configurations": [
     {
-			"name": "Attach to Server",
+      "name": "Attach to Server",
       "type": "node",
       "request": "attach",
-			"port": 6004,
+      "port": 6004,
       "sourceMaps": true,
-  		"outFiles": [
-				"${workspaceRoot}/out/src/**/*.js"
-			]
+      "outFiles": [
+        "${workspaceRoot}/out/src/**/*.js"
+      ]
     },
     {
       "type": "node",

--- a/src/server/processes/bucklescript.ts
+++ b/src/server/processes/bucklescript.ts
@@ -4,9 +4,9 @@ import Session from "../session";
 export default class BuckleScript {
   public readonly process: ChildProcess;
   constructor(session: Session, argsOpt?: string[]) {
-    const command = "bsb"; // TODO get from some settings;
+    const command = session.settings.reason.path.bsb;
     const args = argsOpt || [
-      "-make-world", // TODO run incrementally?
+      "-make-world",
     ];
     this.process = session.environment.spawn(command, args);
     return this;

--- a/src/server/processes/bucklescript.ts
+++ b/src/server/processes/bucklescript.ts
@@ -1,0 +1,14 @@
+import { ChildProcess } from "child_process";
+import Session from "../session";
+
+export default class BuckleScript {
+  public readonly process: ChildProcess;
+  constructor(session: Session, argsOpt?: string[]) {
+    const command = "bsb"; // TODO get from some settings;
+    const args = argsOpt || [
+      "-make-world", // TODO run incrementally?
+    ];
+    this.process = session.environment.spawn(command, args);
+    return this;
+  }
+}

--- a/src/server/processes/index.ts
+++ b/src/server/processes/index.ts
@@ -1,3 +1,4 @@
+import BuckleScript from "./bucklescript";
 import Merlin from "./merlin";
 import OcpIndent from "./ocpIndent";
 import ReFMT from "./refmt";
@@ -6,4 +7,5 @@ export {
   Merlin,
   OcpIndent,
   ReFMT,
+  BuckleScript,
 };

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -48,8 +48,9 @@ export default class Analyzer implements rpc.Disposable {
       }
       const errors = await this.session.merlin.query(merlin.Query.errors(), id);
       if (errors.class !== "return") return;
-      let diagnostics: types.Diagnostic[] = [];
+      const diagnostics: types.Diagnostic[] = [];
       for (const report of errors.value) diagnostics.push(await merlin.IErrorReport.intoCode(this.session, id, report));
+      // this.session.connection.sendDiagnostics({ diagnostics, uri: id.uri });
 
       // TEMP EXPERIMENT
       const bsb = new processes.BuckleScript(this.session).process;
@@ -73,7 +74,7 @@ export default class Analyzer implements rpc.Disposable {
         const startIndex = firstMatch ? firstMatch.index : 0;
         const secondMatch = ansiRegex.exec(fullLine);
         const endIndex = secondMatch ? secondMatch.index : 0;
-        const message = errorMatch[4];
+        const message = errorMatch[4].replace(ansiRegex, "").replace(/\n  /g, "\n");
 
         const newDiagnostic: types.Diagnostic = {
           code: "",
@@ -99,8 +100,6 @@ export default class Analyzer implements rpc.Disposable {
         this.session.connection.sendDiagnostics({ diagnostics: bsbAllDiagnostics[fileUri], uri: fileUri });
       });
       // END - TEMP EXPERIMENT
-
-      // this.session.connection.sendDiagnostics({ diagnostics, uri: id.uri });
     };
   }
 }

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -63,30 +63,28 @@ export default class Analyzer implements rpc.Disposable {
 
       const bsbAllDiagnostics: { [key: string]: types.Diagnostic[] } = {};
 
-      const reErrors = /We've found a bug for you!.+?\n\s*\x1b\[[0-9;]*?m(\S*)\x1b\[[0-9;]*?m\s*?(?:.|\n)*?\x1b\[[0-9;]*?m(\d*)\x1b\[[0-9;]*?m.*? \│ \x1b\[[0-9;]*?m(.*?)\n(?:.|\n)*?\n  \n((?:.|\n)*?)\n  \n/g;
+      const reErrors = /We've found a bug for you!\n\s*(.*), from l(\d*)-c(\d*) to l(\d*)-c(\d*)\n  \n(?:.|\n)*?\n  \n((?:.|\n)*?)\n  \n/g;
       let errorMatch;
+
       while (errorMatch = reErrors.exec(bsbdata)) {
         const fileUri = "file://" + errorMatch[1];
-        const lineNumber = Number(errorMatch[2]) - 1;
-        const fullLine = errorMatch[3];
-        const ansiRegex = /\x1b\[[0-9;]*?m/g;
-        const firstMatch = ansiRegex.exec(fullLine);
-        const startIndex = firstMatch ? firstMatch.index : 0;
-        const secondMatch = ansiRegex.exec(fullLine);
-        const endIndex = secondMatch ? secondMatch.index : 0;
-        const message = errorMatch[4].replace(ansiRegex, "").replace(/\n  /g, "\n");
+        const startLine = Number(errorMatch[2]) - 1;
+        const startCharacter = Number(errorMatch[3]);
+        const endLine = Number(errorMatch[4]) - 1;
+        const endCharacter = Number(errorMatch[5]);
+        const message = errorMatch[6].replace(/\n  /g, "\n");
 
         const newDiagnostic: types.Diagnostic = {
           code: "",
           message,
           range: {
             end: {
-              character: endIndex,
-              line: lineNumber,
+              character: endCharacter,
+              line: endLine,
             },
             start: {
-              character: startIndex,
-              line: lineNumber,
+              character: startCharacter,
+              line: startLine,
             },
           },
           severity: 1,

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -59,7 +59,7 @@ export default class Analyzer implements rpc.Disposable {
           bsbProcess.stdout.on("end", () => resolve(buffer));
         });
 
-        const reErrors = /We've found a bug for you!\n\s*(.*), from l(\d*)-c(\d*) to l(\d*)-c(\d*)\n  \n(?:.|\n)*?\n  \n((?:.|\n)*?)\n  \n/g;
+        const reErrors = /(?:We've found a bug for you!|Warning number \d+)\n\s*(.*), from l(\d*)-c(\d*) to l(\d*)-c(\d*)\n  \n(?:.|\n)*?\n  \n((?:.|\n)*?)\n(?:\[\d+\/\d+\] (?:\x1b\[[0-9;]*?m)?Building|ninja: build stopped:)/g;
         let errorMatch;
 
         while (errorMatch = reErrors.exec(bsbOutput)) {
@@ -83,7 +83,7 @@ export default class Analyzer implements rpc.Disposable {
                 line: startLine,
               },
             },
-            severity: 1,
+            severity: /^Warning number \d+/.exec(errorMatch[0]) ? types.DiagnosticSeverity.Warning : types.DiagnosticSeverity.Error,
             source: "bucklescript",
           };
 

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -47,10 +47,7 @@ export default class Analyzer implements rpc.Disposable {
   public refreshWithKind(syncKind: server.TextDocumentSyncKind): (id: types.TextDocumentIdentifier) => Promise<void> {
     return async (id) => {
 
-      const diagnosticTool: Set<string> = new Set(this.session.settings.reason.diagnostics.tool);
-
-      const bsbEnabled = diagnosticTool.has("bsb") || diagnosticTool.has("both");
-      const merlinEnabled = diagnosticTool.has("merlin") || diagnosticTool.has("both");
+      const bsbEnabled = this.session.settings.reason.bsb.enabled;
 
       // Reset state for every run. This currently can hide valid warnings in some cases
       // as they are not cached, but the alternative (trying to keep track of them) will
@@ -82,7 +79,7 @@ export default class Analyzer implements rpc.Disposable {
         });
       }
 
-      if (merlinEnabled && syncKind !== server.TextDocumentSyncKind.Full || Object.keys(this.bsbDiagnostics).length === 0) {
+      if (!bsbEnabled || syncKind !== server.TextDocumentSyncKind.Full || Object.keys(this.bsbDiagnostics).length === 0) {
         if (syncKind === server.TextDocumentSyncKind.Full) {
           const document = await command.getTextDocument(this.session, id);
           if (null != document) await this.session.merlin.sync(merlin.Sync.tell("start", "end", document.getText()), id);

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -59,7 +59,15 @@ export default class Analyzer implements rpc.Disposable {
           bsbProcess.stdout.on("end", () => resolve(buffer));
         });
 
-        const reErrors = /(?:We've found a bug for you!|Warning number \d+)\n\s*(.*), from l(\d*)-c(\d*) to l(\d*)-c(\d*)\n  \n(?:.|\n)*?\n  \n((?:.|\n)*?)\n(?:\[\d+\/\d+\] (?:\x1b\[[0-9;]*?m)?Building|ninja: build stopped:)/g;
+        const reErrors = new RegExp ([
+          /(?:We've found a bug for you!|Warning number \d+)\n\s*/, // Heading of the error / warning
+          /(.*), from l(\d*)-c(\d*) to l(\d*)-c(\d*)\n  \n/, // Capturing file name and lines / indexes
+          /(?:.|\n)*?\n  \n/, // Ignoring actual lines content being printed
+          /((?:.|\n)*?)\n/, // Capturing error / warning message
+          // TODO: Improve message tail/ending pattern in Bucklescript to ease this detection
+          /(?:\[\d+\/\d+\] (?:\x1b\[[0-9;]*?m)?Building|ninja: build stopped:)/, // Tail
+        ].map((r) => r.source).join(""), "g");
+
         let errorMatch;
 
         while (errorMatch = reErrors.exec(bsbOutput)) {

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -70,16 +70,10 @@ export default class Analyzer implements rpc.Disposable {
           bsbProcess.stdout.on("end", () => resolve(buffer));
         });
 
-        const syntaxErrorDiagnostics = parser.bucklescript.parseSyntaxErrors(bsbOutput);
-        Object.keys(syntaxErrorDiagnostics).forEach((fileUri) => {
+        const diagnostics = parser.bucklescript.parseErrors(bsbOutput);
+        Object.keys(diagnostics).forEach((fileUri) => {
           if (!this.bsbDiagnostics[fileUri]) { this.bsbDiagnostics[fileUri] = []; }
-          this.bsbDiagnostics[fileUri] = this.bsbDiagnostics[fileUri].concat(syntaxErrorDiagnostics[fileUri]);
-        });
-
-        const typeErrorDiagnostics = parser.bucklescript.parseTypeErrors(bsbOutput);
-        Object.keys(typeErrorDiagnostics).forEach((fileUri) => {
-          if (!this.bsbDiagnostics[fileUri]) { this.bsbDiagnostics[fileUri] = []; }
-          this.bsbDiagnostics[fileUri] = this.bsbDiagnostics[fileUri].concat(typeErrorDiagnostics[fileUri]);
+          this.bsbDiagnostics[fileUri] = this.bsbDiagnostics[fileUri].concat(diagnostics[fileUri]);
         });
 
         Object.keys(this.bsbDiagnostics).forEach((fileUri) => {

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -1,7 +1,7 @@
 import * as _ from "lodash";
 import * as rpc from "vscode-jsonrpc";
 import * as server from "vscode-languageserver";
-import { merlin, types } from "../../shared";
+import { merlin, parser, types } from "../../shared";
 import * as command from "../command";
 import * as processes from "../processes";
 import Session from "./index";
@@ -65,50 +65,24 @@ export default class Analyzer implements rpc.Disposable {
           bsbProcess.stdout.on("end", () => resolve(buffer));
         });
 
-        const reErrors = new RegExp ([
-          /(?:We've found a bug for you!|Warning number \d+)\n\s*/, // Heading of the error / warning
-          /(.*), from l(\d*)-c(\d*) to l(\d*)-c(\d*)\n  \n/, // Capturing file name and lines / indexes
-          /(?:.|\n)*?\n  \n/, // Ignoring actual lines content being printed
-          /((?:.|\n)*?)/, // Capturing error / warning message
-          // TODO: Improve message tail/ending pattern in Bucklescript to ease this detection
-          /(?:\n\[\d+\/\d+\] (?:\x1b\[[0-9;]*?m)?Building|\nninja: build stopped:|(?=Warning number \d+)|$)/, // Tail
-        ].map((r) => r.source).join(""), "g");
-
-        let errorMatch;
-
-        while (errorMatch = reErrors.exec(bsbOutput)) {
-          const fileUri = "file://" + errorMatch[1];
-          const startLine = Number(errorMatch[2]) - 1;
-          const startCharacter = Number(errorMatch[3]);
-          const endLine = Number(errorMatch[4]) - 1;
-          const endCharacter = Number(errorMatch[5]);
-          const message = errorMatch[6].replace(/\n  /g, "\n");
-
-          const bsbDiagnostic: types.Diagnostic = {
-            code: "",
-            message,
-            range: {
-              end: {
-                character: endCharacter,
-                line: endLine,
-              },
-              start: {
-                character: startCharacter,
-                line: startLine,
-              },
-            },
-            severity: /^Warning number \d+/.exec(errorMatch[0]) ? types.DiagnosticSeverity.Warning : types.DiagnosticSeverity.Error,
-            source: "bucklescript",
-          };
-
+        const syntaxErrorDiagnostics = parser.bucklescript.parseSyntaxErrors(bsbOutput);
+        Object.keys(syntaxErrorDiagnostics).forEach((fileUri) => {
           if (!this.bsbDiagnostics[fileUri]) { this.bsbDiagnostics[fileUri] = []; }
-          this.bsbDiagnostics[fileUri].push(bsbDiagnostic);
-        }
+          this.bsbDiagnostics[fileUri] = this.bsbDiagnostics[fileUri].concat(syntaxErrorDiagnostics[fileUri]);
+        });
+
+        const typeErrorDiagnostics = parser.bucklescript.parseTypeErrors(bsbOutput);
+        Object.keys(typeErrorDiagnostics).forEach((fileUri) => {
+          if (!this.bsbDiagnostics[fileUri]) { this.bsbDiagnostics[fileUri] = []; }
+          this.bsbDiagnostics[fileUri] = this.bsbDiagnostics[fileUri].concat(typeErrorDiagnostics[fileUri]);
+        });
+
         Object.keys(this.bsbDiagnostics).forEach((fileUri) => {
           this.session.connection.sendDiagnostics({ diagnostics: this.bsbDiagnostics[fileUri], uri: fileUri });
           if (this.bsbDiagnostics[fileUri].length === 0) { delete this.bsbDiagnostics[fileUri]; }
         });
       }
+
       if (syncKind !== server.TextDocumentSyncKind.Full || Object.keys(this.bsbDiagnostics).length === 0) {
         if (syncKind === server.TextDocumentSyncKind.Full) {
           const document = await command.getTextDocument(this.session, id);

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -5,15 +5,15 @@ import * as types from "./types";
 
 export interface ISettings {
   reason: {
+    bsb: {
+      enabled: boolean;
+    };
     codelens: {
       enabled: boolean;
       unicode: boolean;
     };
     debounce: {
       linter: number;
-    };
-    diagnostics: {
-      tool: Array<"merlin" | "bsb" | "both">;
     };
     path: {
       bsb: string;
@@ -33,15 +33,15 @@ export interface ISettings {
 export namespace ISettings {
   export const defaults: ISettings = {
     reason: {
+      bsb: {
+        enabled: false,
+      },
       codelens: {
         enabled: true,
         unicode: true,
       },
       debounce: {
         linter: 500,
-      },
-      diagnostics: {
-        tool: ["merlin"],
       },
       path: {
         bsb: "bsb",

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -12,6 +12,9 @@ export interface ISettings {
     debounce: {
       linter: number;
     };
+    diagnostics: {
+      tool: Array<"merlin" | "bsb" | "both">;
+    };
     path: {
       bsb: string;
       ocamlfind: string;
@@ -36,6 +39,9 @@ export namespace ISettings {
       },
       debounce: {
         linter: 500,
+      },
+      diagnostics: {
+        tool: ["merlin"],
       },
       path: {
         bsb: "bsb",

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -38,6 +38,7 @@ export namespace ISettings {
         linter: 500,
       },
       path: {
+        bsb: "bsb",
         ocamlfind: "ocamlfind",
         ocamlmerlin: "ocamlmerlin",
         opam: "opam",

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -13,6 +13,7 @@ export interface ISettings {
       linter: number;
     };
     path: {
+      bsb: string;
       ocamlfind: string;
       ocamlmerlin: string;
       opam: string;

--- a/src/shared/parser/bucklescript/index.ts
+++ b/src/shared/parser/bucklescript/index.ts
@@ -54,9 +54,9 @@ export function parseTypeErrors(bsbOutput: string): { [key: string]: types.Diagn
     const fileUri = "file://" + errorMatch[1];
     // Suppose most complex case, path/to/file.re 10:20-15:5 message
     const startLine = Number(errorMatch[2]) - 1;
-    const startCharacter = Number(errorMatch[3]);
+    const startCharacter = Number(errorMatch[3]) - 1;
     let endLine = Number(errorMatch[4]) - 1;
-    let endCharacter = Number(errorMatch[5]);
+    let endCharacter = Number(errorMatch[5]); // Non inclusive originally
     const message = errorMatch[6].replace(/\n  /g, "\n");
     if (isNaN(endLine)) {
       // Format path/to/file.re 10:20 message
@@ -64,7 +64,7 @@ export function parseTypeErrors(bsbOutput: string): { [key: string]: types.Diagn
       endLine = startLine;
     } else if (isNaN(endCharacter)) {
       // Format path/to/file.re 10:20-15 message
-      endCharacter = endLine; // Format is L:SC-EC
+      endCharacter = endLine + 1; // Format is L:SC-EC
       endLine = startLine;
     }
 

--- a/src/shared/parser/bucklescript/index.ts
+++ b/src/shared/parser/bucklescript/index.ts
@@ -1,0 +1,82 @@
+import { types } from "../../../shared";
+
+export function parseSyntaxErrors(bsbOutput: string): { [key: string]: types.Diagnostic[] } {
+  const parsedDiagnostics = {};
+
+  const reSyntaxErrors = new RegExp ([
+    /File "(.*)", line (\d*), characters (\d*)-(\d*):[\s\S]*?/,
+    /Error: (.*?)\n[\s\S]*?We've found a bug for you!/,
+  ].map((r) => r.source).join(""), "g");
+
+  let errorMatch;
+  while (errorMatch = reSyntaxErrors.exec(bsbOutput)) {
+    const fileUri = "file://" + errorMatch[1];
+    const startLine = Number(errorMatch[2]) - 1;
+    const endLine = Number(errorMatch[2]) - 1;
+    const startCharacter = Number(errorMatch[3]);
+    const endCharacter = Number(errorMatch[4]);
+    const message = errorMatch[5].trim();
+
+    const diagnostic: types.Diagnostic = {
+      code: "",
+      message,
+      range: {
+        end: {
+          character: endCharacter,
+          line: endLine,
+        },
+        start: {
+          character: startCharacter,
+          line: startLine,
+        },
+      },
+      severity: /^Warning number \d+/.exec(errorMatch[0]) ? types.DiagnosticSeverity.Warning : types.DiagnosticSeverity.Error,
+      source: "bucklescript",
+    };
+    if (!parsedDiagnostics[fileUri]) { parsedDiagnostics[fileUri] = []; }
+    parsedDiagnostics[fileUri].push(diagnostic);
+  }
+  return parsedDiagnostics;
+}
+
+export function parseTypeErrors(bsbOutput: string): { [key: string]: types.Diagnostic[] } {
+  const parsedDiagnostics = {};
+  const reTypeErrors = new RegExp ([
+    /(?:We've found a bug for you!|Warning number \d+)\n\s*/, // Heading of the error / warning
+    /(.*), from l(\d*)-c(\d*) to l(\d*)-c(\d*)\n  \n/, // Capturing file name and lines / indexes
+    /(?:.|\n)*?\n  \n/, // Ignoring actual lines content being printed
+    /((?:.|\n)*?)/, // Capturing error / warning message
+    // TODO: Improve message tail/ending pattern in Bucklescript to ease this detection
+    /(?:\n\[\d+\/\d+\] (?:\x1b\[[0-9;]*?m)?Building|\nninja: build stopped:|(?=Warning number \d+)|$)/, // Tail
+  ].map((r) => r.source).join(""), "g");
+
+  let errorMatch;
+  while (errorMatch = reTypeErrors.exec(bsbOutput)) {
+    const fileUri = "file://" + errorMatch[1];
+    const startLine = Number(errorMatch[2]) - 1;
+    const startCharacter = Number(errorMatch[3]);
+    const endLine = Number(errorMatch[4]) - 1;
+    const endCharacter = Number(errorMatch[5]);
+    const message = errorMatch[6].replace(/\n  /g, "\n");
+
+    const diagnostic: types.Diagnostic = {
+      code: "",
+      message,
+      range: {
+        end: {
+          character: endCharacter,
+          line: endLine,
+        },
+        start: {
+          character: startCharacter,
+          line: startLine,
+        },
+      },
+      severity: /^Warning number \d+/.exec(errorMatch[0]) ? types.DiagnosticSeverity.Warning : types.DiagnosticSeverity.Error,
+      source: "bucklescript",
+    };
+    if (!parsedDiagnostics[fileUri]) { parsedDiagnostics[fileUri] = []; }
+    parsedDiagnostics[fileUri].push(diagnostic);
+  }
+  return parsedDiagnostics;
+}

--- a/src/shared/parser/bucklescript/index.ts
+++ b/src/shared/parser/bucklescript/index.ts
@@ -46,7 +46,7 @@ export function parseTypeErrors(bsbOutput: string): { [key: string]: types.Diagn
     /(.*) (\d+):(\d+)(?:-(\d+)(?::(\d+))?)?\n  \n/, // Capturing file name and lines / indexes
     /(?:.|\n)*?\n  \n/, // Ignoring actual lines content being printed
     /((?:.|\n)*?)/, // Capturing error / warning message
-    /(?:\n\S|(?=Warning number \d+)|$)/, // Tail
+    /((?=We've found a bug for you!)|(?:ninja: build stopped: subcommand failed)|(?=Warning number \d+)|$)/, // Tail
   ].map((r) => r.source).join(""), "g");
 
   let errorMatch;

--- a/src/shared/parser/index.ts
+++ b/src/shared/parser/index.ts
@@ -1,5 +1,7 @@
+import * as bucklescript from "./bucklescript";
 import * as ocamldoc from "./ocamldoc";
 
 export {
+  bucklescript,
   ocamldoc,
 };


### PR DESCRIPTION
⚠️  WIP ⚠️ 

Targets #17.

### TODO

~~- [ ] Make it work also on edit (not only save)~~ Edit: Deferred, can't see an easy way to do so, unless there's some way to plug the edited file input to `bsb`?
~~- [ ] Create PR to allow ninja to print colors upstream (BuckleScript)~~ Edit: not needed after adding explicit output
- [x] Multiple files
- [x] Line numbers? (https://github.com/BuckleScript/bucklescript/issues/2015)
- [x] Match file paths from bsb output to the current vscode document
- [x] Send empty diagnostics array for files after being fixed
- [ ] Multiple errors per file (is it possible?)
- [x] Check for `bsconfig.json`? Edit: read bsb path from settings

### Bugs:
~~- [ ] Error with no lines:~~ Covered in https://github.com/freebroccolo/ocaml-language-server/issues/34
```
while (current <: !(length input)) {
};
```
~~- [ ] Fatal error not parsed:~~ (can't repro 😕 )
```
BSB check build spec : OK 

Making the dependency world!
Package stack: the-super-tiny-compiler  
ninja.exe -C lib/bs 
ninja: Entering directory `lib/bs'
[1/1] Building src/compiler-TheSuperTinyCompiler.cmj
FAILED: src/compiler-TheSuperTinyCompiler.cmj /Users/javi/Development/github/the-super-tiny-compiler/lib/js/src/compiler.js src/compiler-TheSuperTinyCompiler.cmi 
/Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/bsc.exe -bs-package-map the-super-tiny-compiler  -bs-package-output commonjs:lib/js/src -bs-assume-no-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include  -I . -I src   -nostdlib -I '/Users/javi/Development/github/the-super-tiny-compiler/node_modules/bs-platform/lib/ocaml' -bs-super-errors -no-alias-deps -color always -w -40+6+7+27+32..39+44+45 -bs-re-error -o src/compiler-TheSuperTinyCompiler.cmj -c  src/compiler.mlast 
Fatal error: exception Failure("File \"syntax/ast_ffi_types.ml\", line 253, characters 13-20compiler version mismatch, please do a clean build")
ninja: build stopped: subcommand failed.
Error: Command failed: /Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/bsb.exe -make-world
Error happened when running command /Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/bsb.exe with args [ '-make-world' ]
```

- [x] Badly parsed error (see [gist with repro](https://gist.github.com/jchavarri/06a1874e6940ee73a60b228aca682ee6))
```
        ens initialMachine.state
  444 │ };
  
  You forgot to handle a possible value here, for example: 
([], Some _, _, _) // This is not parsed
```