### PR TITLE
Check if bsbDiagnostics exist when clearing after a file is closed

### DIFF
--- a/src/server/processes/merlin.ts
+++ b/src/server/processes/merlin.ts
@@ -8,7 +8,7 @@ import { merlin, types } from "../../shared";
 import Session from "../session";
 
 export default class Merlin implements rpc.Disposable {
-  private readonly queue: AsyncPriorityQueue<any>;
+  private readonly queue: async.AsyncPriorityQueue<any>;
   private readline: readline.ReadLine;
   private process: childProcess.ChildProcess;
   private readonly session: Session;

--- a/src/server/processes/merlin.ts
+++ b/src/server/processes/merlin.ts
@@ -8,7 +8,7 @@ import { merlin, types } from "../../shared";
 import Session from "../session";
 
 export default class Merlin implements rpc.Disposable {
-  private readonly queue: async.AsyncPriorityQueue<any>;
+  private readonly queue: AsyncPriorityQueue<any>;
   private readline: readline.ReadLine;
   private process: childProcess.ChildProcess;
   private readonly session: Session;

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -19,7 +19,7 @@ export default class Analyzer implements rpc.Disposable {
   }
 
   public clear(event: types.TextDocumentIdentifier): void {
-    if (this.bsbDiagnostics[event.uri].length > 0 && this.bsbDiagnostics[event.uri][0].source !== "bucklescript") {
+    if (this.bsbDiagnostics[event.uri] && this.bsbDiagnostics[event.uri].length > 0 && this.bsbDiagnostics[event.uri][0].source !== "bucklescript") {
       this.session.connection.sendDiagnostics({
         diagnostics: [],
         uri: event.uri,

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -19,7 +19,7 @@ export default class Analyzer implements rpc.Disposable {
   }
 
   public clear(event: types.TextDocumentIdentifier): void {
-    if (this.bsbDiagnostics[event.uri] && this.bsbDiagnostics[event.uri].length > 0 && this.bsbDiagnostics[event.uri][0].source !== "bucklescript") {
+    if (this.bsbDiagnostics[event.uri] && this.bsbDiagnostics[event.uri][0] && this.bsbDiagnostics[event.uri][0].source !== "bucklescript") {
       this.session.connection.sendDiagnostics({
         diagnostics: [],
         uri: event.uri,


### PR DESCRIPTION
Seems this regressed in #32 😁  The outcome was

```
[Error - 3:20:18 PM] Notification handler 'textDocument/didClose' failed with message:
Cannot read property 'length' of undefined
```

errors were appearing when closing a Reason file.

I wouldn't be surprised if this is somehow related to https://github.com/freebroccolo/ocaml-language-server/issues/36.

@freebroccolo Could you review please? I also removed the `async` from `async.AsyncPriorityQueue` as it was not allowing me to compile.