### PR TITLE
Replace reason.bsb.enabled with reason.diagnostics.tools

### DIFF
--- a/src/server/processes/bucklescript.ts
+++ b/src/server/processes/bucklescript.ts
@@ -3,12 +3,31 @@ import Session from "../session";
 
 export default class BuckleScript {
   public readonly process: ChildProcess;
-  constructor(session: Session, argsOpt?: string[]) {
-    const command = session.settings.reason.path.bsb;
-    const args = argsOpt || [
-      "-make-world",
-    ];
-    this.process = session.environment.spawn(command, args);
+  private readonly session: Session;
+  constructor(session: Session) {
+    this.session = session;
     return this;
+  }
+
+  public run(): Promise<string> {
+    let buffer = "";
+    return new Promise((resolve) => {
+      const command = this.session.settings.reason.path.bsb;
+      const args = [
+        "-make-world",
+      ];
+      const process = this.session.environment.spawn(command, args);
+
+      process.on("error", (error: Error & { code: string }) => {
+        if (error.code === "ENOENT") {
+          const msg = `Cannot find bsb binary at "${command}".`;
+          this.session.connection.window.showWarningMessage(msg);
+          this.session.connection.window.showWarningMessage(`Double check your path or try configuring "reason.path.bsb" under "User Settings". Alternatively, disable "bsb" in "reason.diagnostics.tools"`);
+        }
+        resolve("");
+      });
+      process.stdout.on("data", (data: Buffer | string) => buffer += data.toString());
+      process.stdout.on("end", () => resolve(buffer));
+    });
   }
 }

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -60,13 +60,8 @@ export default class Analyzer implements rpc.Disposable {
 
       if (tools.has("bsb") && syncKind === server.TextDocumentSyncKind.Full) {
         this.refreshDebounced.cancel();
-        const bsbProcess = new processes.BuckleScript(this.session).process;
-        const bsbOutput = await new Promise<string>((resolve, reject) => {
-          let buffer = "";
-          bsbProcess.stdout.on("error", (error: Error) => reject(error));
-          bsbProcess.stdout.on("data", (data: Buffer | string) => buffer += data.toString());
-          bsbProcess.stdout.on("end", () => resolve(buffer));
-        });
+        const bsbProcess = new processes.BuckleScript(this.session);
+        const bsbOutput = await bsbProcess.run();
 
         const diagnostics = parser.bucklescript.parseErrors(bsbOutput);
         Object.keys(diagnostics).forEach((fileUri) => {

--- a/src/server/session/analyzer.ts
+++ b/src/server/session/analyzer.ts
@@ -47,7 +47,8 @@ export default class Analyzer implements rpc.Disposable {
   public refreshWithKind(syncKind: server.TextDocumentSyncKind): (id: types.TextDocumentIdentifier) => Promise<void> {
     return async (id) => {
 
-      const bsbEnabled = this.session.settings.reason.bsb.enabled;
+      const tools: Set<string> = new Set(this.session.settings.reason.diagnostics.tools);
+      if (tools.size < 1) return;
 
       // Reset state for every run. This currently can hide valid warnings in some cases
       // as they are not cached, but the alternative (trying to keep track of them) will
@@ -57,7 +58,7 @@ export default class Analyzer implements rpc.Disposable {
       });
       this.bsbDiagnostics[id.uri] = [];
 
-      if (bsbEnabled && syncKind === server.TextDocumentSyncKind.Full) {
+      if (tools.has("bsb") && syncKind === server.TextDocumentSyncKind.Full) {
         this.refreshDebounced.cancel();
         const bsbProcess = new processes.BuckleScript(this.session).process;
         const bsbOutput = await new Promise<string>((resolve, reject) => {
@@ -77,9 +78,7 @@ export default class Analyzer implements rpc.Disposable {
           this.session.connection.sendDiagnostics({ diagnostics: this.bsbDiagnostics[fileUri], uri: fileUri });
           if (this.bsbDiagnostics[fileUri].length === 0) { delete this.bsbDiagnostics[fileUri]; }
         });
-      }
-
-      if (!bsbEnabled || syncKind !== server.TextDocumentSyncKind.Full || Object.keys(this.bsbDiagnostics).length === 0) {
+      } else if (tools.has("merlin")) {
         if (syncKind === server.TextDocumentSyncKind.Full) {
           const document = await command.getTextDocument(this.session, id);
           if (null != document) await this.session.merlin.sync(merlin.Sync.tell("start", "end", document.getText()), id);

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -5,15 +5,15 @@ import * as types from "./types";
 
 export interface ISettings {
   reason: {
-    bsb: {
-      enabled: boolean;
-    };
     codelens: {
       enabled: boolean;
       unicode: boolean;
     };
     debounce: {
       linter: number;
+    };
+    diagnostics: {
+      tools: Array<"merlin" | "bsb">,
     };
     path: {
       bsb: string;
@@ -33,15 +33,15 @@ export interface ISettings {
 export namespace ISettings {
   export const defaults: ISettings = {
     reason: {
-      bsb: {
-        enabled: false,
-      },
       codelens: {
         enabled: true,
         unicode: true,
       },
       debounce: {
         linter: 500,
+      },
+      diagnostics: {
+        tools: ["merlin"],
       },
       path: {
         bsb: "bsb",


### PR DESCRIPTION
Companion PR of https://github.com/reasonml-editor/vscode-reasonml/pull/112.

There was some feedback on Discord about users wanting more control over which tool would be used for diagnostic. This PR changes `bsb.enabled` (boolean) with `diagnostics.tools`(array) so users can decide if they want `merlin`, `bsb` or both, or none :)

@freebroccolo @chenglou What do you think? cc @superherointj 