### PR TITLE
Fix a couple of bsb parsing cases

### DIFF
--- a/src/shared/parser/bucklescript/index.ts
+++ b/src/shared/parser/bucklescript/index.ts
@@ -31,7 +31,7 @@ export function parseErrors(bsbOutput: string): { [key: string]: types.Diagnosti
 
   const reLevel1Errors = new RegExp ([
     /File "(.*)", line (\d*), characters (\d*)-(\d*):[\s\S]*?/,
-    /Error: (.*?)\n[\s\S]*?We've found a bug for you!/,
+    /Error: ([\s\S]*)We've found a bug for you!/,
   ].map((r) => r.source).join(""), "g");
 
   let errorMatch;
@@ -61,7 +61,7 @@ export function parseErrors(bsbOutput: string): { [key: string]: types.Diagnosti
     /(.*) (\d+):(\d+)(?:-(\d+)(?::(\d+))?)?\n  \n/, // Capturing file name and lines / indexes
     /(?:.|\n)*?\n  \n/, // Ignoring actual lines content being printed
     /((?:.|\n)*?)/, // Capturing error / warning message
-    /((?=We've found a bug for you!)|(?:ninja: build stopped: subcommand failed)|(?=Warning number \d+)|$)/, // Tail
+    /((?=We've found a bug for you!)|(?:\[\d+\/\d+\] (?:\x1b\[[0-9;]*?m)?Building)|(?:ninja: build stopped: subcommand failed)|(?=Warning number \d+)|$)/, // Possible tails
   ].map((r) => r.source).join(""), "g");
 
   while (errorMatch = reLevel2Errors.exec(bsbOutput)) {


### PR DESCRIPTION
I realized today two cases that were not being covered with the existing regexps. 

---

**1. Indented parts of the error message:**

for example, this code:

```
let debugAstNode astNode =>
  switch astNode {
    | result (NumberLiteral n) => "Number " ^ n
    | result (StringLiteral s => "String " ^ s
    | result (CallExpression n _) => "CallExpression " ^ n
    | result (CallExpression n _) => "CallExpression " ^ n
    | error msg => "Error when parsing: " ^ msg
  };
```

triggered this output:
```
File "/Users/javi/Development/github/the-super-tiny-compiler/src/compiler.re", line 498, characters 13-14:
Error: 1087: Expecting one of the following:
  - "|" to open the next pattern
  - "=>" to start the body of the matched pattern
  - "when" to start a contitional guard for the previous pattern


  We've found a bug for you!
  /Users/javi/Development/github/the-super-tiny-compiler/src/compiler.re
```

But the server was only returning `Error 1087: Expecting one of the following:`.

Changing the level 1 regexp to be more greedy fixes it (match everything until `We've found a bug for you`). 

---

**2. Multiple files with errors:**

An output like this

```
> bsb -make-world

ninja: Entering directory `lib/bs'
[2/2] Building src/demo.mlast.d
[1/4] Building src/d3.cmj
FAILED: src/d3.cmj /Users/javi/Development/sandbox/reason-hello/lib/js/src/d3.js src/d3.cmi 
/Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/bsc.exe -bs-package-name reason-hello  -bs-package-output commonjs:lib/js/src -bs-assume-no-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include  -I src   -nostdlib -I '/Users/javi/Development/sandbox/reason-hello/node_modules/bs-platform/lib/ocaml' -bs-super-errors -no-alias-deps -color always -w -40+6+7+27+32..39+44+45 -bs-re-error -o src/d3.cmj -c  src/d3.mlast 

  We've found a bug for you!
  
  
  Unbound value <:
  
[2/4] Building src/a.cmj
FAILED: src/a.cmj /Users/javi/Development/sandbox/reason-hello/lib/js/src/a.js src/a.cmi 
/Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/bsc.exe -bs-package-name reason-hello  -bs-package-output commonjs:lib/js/src -bs-assume-no-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include  -I src   -nostdlib -I '/Users/javi/Development/sandbox/reason-hello/node_modules/bs-platform/lib/ocaml' -bs-super-errors -no-alias-deps -color always -w -40+6+7+27+32..39+44+45 -bs-re-error -o src/a.cmj -c  src/a.mlast 

  We've found a bug for you!
  /Users/javi/Development/sandbox/reason-hello/src/a.re 2:8-17
  
  1 │ let debugAstNode astNode =>
  2 │ switch astsdfNode {
  3 │   | true => "Error when parsing: " ^ msg
  4 │ };
  
  Unbound value astsdfNode
  
  Hint: Did you mean astNode?
  
[3/4] Building src/demo.cmj
FAILED: src/demo.cmj /Users/javi/Development/sandbox/reason-hello/lib/js/src/demo.js src/demo.cmi 
/Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/bsc.exe -bs-package-name reason-hello  -bs-package-output commonjs:lib/js/src -bs-assume-no-mli -bs-no-builtin-ppx-ml -bs-no-implicit-include  -I src   -nostdlib -I '/Users/javi/Development/sandbox/reason-hello/node_modules/bs-platform/lib/ocaml' -bs-super-errors -no-alias-deps -color always -w -40+6+7+27+32..39+44+45 -bs-re-error -o src/demo.cmj -c  src/demo.mlast 

  We've found a bug for you!
  /Users/javi/Development/sandbox/reason-hello/src/demo.re 59:9-23
  
  57 │   };
  58 │ 
  59 │ Js.log (pattesdfrnMatch test other);
  60 │ 
  61 │ /* Records */
  
  Unbound value pattesdfrnMatch
  
  Hint: Did you mean patternMatch?
  
ninja: build stopped: subcommand failed.
```

was causing wrong messages (`[3/4] Building src/demo.cmj...` would be part of the message). Taking `[n/n] Building` into account on the regexp fixes it.

_Side note: we should probably add some tests for this, depending on how long we will be relying on this hack to parse `bsb` output. I could maybe help with that_ :)