### PR TITLE
Properly handle n:m line:char format

### DIFF
--- a/src/shared/parser/bucklescript/index.ts
+++ b/src/shared/parser/bucklescript/index.ts
@@ -74,7 +74,7 @@ export function parseErrors(bsbOutput: string): { [key: string]: types.Diagnosti
     const message = errorMatch[6].replace(/\n  /g, "\n");
     if (isNaN(endLine)) {
       // Format path/to/file.re 10:20 message
-      endCharacter = startCharacter;
+      endCharacter = startCharacter + 1;
       endLine = startLine;
     } else if (isNaN(endCharacter)) {
       // Format path/to/file.re 10:20-15 message


### PR DESCRIPTION
Found by @chenglou. This was making empty ranges, for example, `1:16` would set `startCharacter` and `endCharacter` both have `15` as value, which vscode didn't understand.

Testing input:

```
let asd:string=1;
```