### PR TITLE
Strengthen level 1 errors parsing

### DIFF
--- a/src/shared/parser/bucklescript/index.ts
+++ b/src/shared/parser/bucklescript/index.ts
@@ -31,7 +31,7 @@ export function parseErrors(bsbOutput: string): { [key: string]: types.Diagnosti
 
   const reLevel1Errors = new RegExp ([
     /File "(.*)", line (\d*), characters (\d*)-(\d*):[\s\S]*?/,
-    /Error: ([\s\S]*)We've found a bug for you!/,
+    /Error: ([\s\S]*)(We've found a bug for you!|File "(.*)", line (\d*):\nError: Error while running external preprocessor)/,
   ].map((r) => r.source).join(""), "g");
 
   let errorMatch;


### PR DESCRIPTION
Small fix for a `bsb` parsing error when working with JSX that was reported on Discord.

```reason
/* MyForm.re */
type action =
  | Click
  | Toggle;

type state = {count: int, show: bool};

let component = ReasonReact.reducerComponent "MyForm";

let make _children => {
  ...component,
  initialState: fun () => {count: 0, show: false},
  reducer: fun action state =>
    switch action {
    | Click => ReasonReact.NoUpdate ,
    },
  render: fun self => {
    let message = "Clicked " ^ string_of_int self.state.count ^ " times(s)";
    <div></div>
  }
};
```

The indicator should appear at the end of the line containing `| Click => ReasonReact.NoUpdate ,`.

`bsb` output:

```
ninja: Entering directory `lib/bs'
[1/2] Building src/simple/bla.mlast
FAILED: src/simple/bla.mlast 
/Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/bsc.exe -pp "/Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/refmt.exe --print binary" -ppx '/Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/reactjs_jsx_ppx_2.exe'   -w -30-40+6+7+27+32..39+44+45 -nostdlib -I '/Users/javi/Development/sandbox/reason-react-hello/node_modules/bs-platform/lib/ocaml' -no-alias-deps -color always -c -o src/simple/bla.mlast -bs-syntax-only -bs-binary-ast -impl /Users/javi/Development/sandbox/reason-react-hello/src/simple/bla.re
File "/Users/javi/Development/sandbox/reason-react-hello/src/simple/bla.re", line 14, characters 36-37:
Error: 2543: The switch expression isn't closed.

File "/Users/javi/Development/sandbox/reason-react-hello/src/simple/bla.re", line 1:
Error: Error while running external preprocessor
Command line: /Users/javi/.nvm/versions/node/v6.9.4/lib/node_modules/bs-platform/bin/refmt.exe --print binary '/Users/javi/Development/sandbox/reason-react-hello/src/simple/bla.re' > /var/folders/ss/97gmv_jn031f29dsvb600f280000gn/T/ocamlpp41b750

ninja: error: rebuilding 'build.ninja': subcommand failed
```