### PR TITLE
Autoload ocaml dependencies from "command-env".

### DIFF
--- a/src/bin/server/feature/didChangeWatchedFiles.ts
+++ b/src/bin/server/feature/didChangeWatchedFiles.ts
@@ -9,6 +9,10 @@ export default function(
     for (const id of event.changes) {
       if (/\.(ml|re)$/.test(id.uri)) return session.indexer.refreshSymbols(id);
       if (/\.(merlin)$/.test(id.uri)) return command.restartMerlin(session);
+      if (/(command-env-exec)$/.test(id.uri))
+        return command.restartMerlin(session);
+      if (/(command-env-exec.cmd)$/.test(id.uri))
+        return command.restartMerlin(session);
     }
   };
 }

--- a/src/bin/server/feature/didChangeWatchedFiles.ts
+++ b/src/bin/server/feature/didChangeWatchedFiles.ts
@@ -9,9 +9,9 @@ export default function(
     for (const id of event.changes) {
       if (/\.(ml|re)$/.test(id.uri)) return session.indexer.refreshSymbols(id);
       if (/\.(merlin)$/.test(id.uri)) return command.restartMerlin(session);
-      if (/(command-env-exec)$/.test(id.uri))
+      if (/(command-exec)$/.test(id.uri))
         return command.restartMerlin(session);
-      if (/(command-env-exec.cmd)$/.test(id.uri))
+      if (/(command-exec.cmd)$/.test(id.uri))
         return command.restartMerlin(session);
     }
   };

--- a/src/bin/server/session/environment.ts
+++ b/src/bin/server/session/environment.ts
@@ -19,7 +19,7 @@ export default class Environment implements server.Disposable {
   }
 
   /**
-   * Projects may optionally generate a command-env-exec runner script.
+   * Projects may optionally generate a command-exec runner script.
    * By outputting this file, projects are opting into having IDE features,
    * executed through a command wrapper which will ensure that all the
    * right build tools and dependencies are made available.
@@ -79,8 +79,8 @@ export default class Environment implements server.Disposable {
           "build",
           "bin",
           process.platform === "win32"
-            ? "command-env-exec.bat"
-            : "command-env-exec",
+            ? "command-exec.bat"
+            : "command-exec",
         );
   }
 

--- a/src/bin/server/session/environment.ts
+++ b/src/bin/server/session/environment.ts
@@ -1,4 +1,5 @@
 import * as childProcess from "child_process";
+import * as fs from "fs";
 import * as path from "path";
 import * as URL from "url";
 import * as server from "vscode-languageserver";
@@ -17,7 +18,22 @@ export default class Environment implements server.Disposable {
     return uri.substr(fileSchemeLength);
   }
 
+  /**
+   * Projects may optionally generate a command-env-exec runner script.
+   * By outputting this file, projects are opting into having IDE features,
+   * executed through a command wrapper which will ensure that all the
+   * right build tools and dependencies are made available.
+   * For example, ocamlfind libraries will be seen, and the correct version
+   * of `refmt` will be selected etc.
+   *
+   */
+  private projectCommandWrapper: null | string = null;
+
   constructor(private readonly session: Session) {}
+
+  public async initialize(): Promise<void> {
+    await this.determineCommandWrapper();
+  }
 
   public dispose(): void {
     return;
@@ -35,10 +51,53 @@ export default class Environment implements server.Disposable {
     options: childProcess.SpawnOptions = {},
   ): childProcess.ChildProcess {
     options.shell = process.platform === "win32" ? true : options.shell;
-    return childProcess.spawn(command, args, options);
+    if (this.projectCommandWrapper !== null) {
+      return childProcess.spawn(
+        this.projectCommandWrapper,
+        [command].concat(args),
+        options,
+      );
+    } else {
+      return childProcess.spawn(command, args, options);
+    }
   }
 
   public workspaceRoot(): string | null | undefined {
     return this.session.initConf.rootPath;
+  }
+
+  private projectCommandWrapperPath(
+    workspaceRoot: string | null | undefined,
+  ): string | null {
+    return workspaceRoot === null || workspaceRoot === undefined
+      ? null
+      : path.join(
+          workspaceRoot,
+          "node_modules",
+          ".cache",
+          "_esy",
+          "build",
+          "bin",
+          process.platform === "win32"
+            ? "command-env-exec.bat"
+            : "command-env-exec",
+        );
+  }
+
+  private async determineCommandWrapper(): Promise<void> {
+    const workspaceRoot = this.workspaceRoot();
+    try {
+      const projectCommandWrapper = this.projectCommandWrapperPath(
+        workspaceRoot,
+      );
+      if (projectCommandWrapper !== null) {
+        const exists = await fs.existsSync(projectCommandWrapper);
+        this.projectCommandWrapper = exists ? projectCommandWrapper : null;
+      }
+    } catch (err) {
+      this.session.error(
+        `Error determining if command wrapper exists at: ${workspaceRoot}`,
+      );
+    }
   }
 }

--- a/src/bin/server/session/index.ts
+++ b/src/bin/server/session/index.ts
@@ -36,6 +36,7 @@ export default class Session implements server.Disposable {
   }
 
   public async initialize(): Promise<void> {
+    await this.environment.initialize();
     await this.merlin.initialize();
     await this.indexer.initialize();
     await this.synchronizer.initialize();
@@ -49,6 +50,10 @@ export default class Session implements server.Disposable {
 
   public log(data: any): void {
     this.connection.console.log(JSON.stringify(data, null as any, 2)); // tslint:disable-line
+  }
+
+  public error(data: any): void {
+    this.connection.console.error(JSON.stringify(data, null as any, 2)); // tslint:disable-line
   }
 
   public onDidChangeConfiguration({


### PR DESCRIPTION
Summary: The [`esy`](https://github.com/esy/esy) project manager outputs a `command-exec` that wraps arbitrary commands, such that those commands will see all of the `ocamlfind` dependencies of a specific project.

What this diff accomplishes:
- Makes `ocaml-language-server` automatically work with any Reason/OCaml project that installs dependencies with `esy`.
- Just open VSCode on any `esy` project after building and autocompletion will just work.
- Allows different workspaces to be edited simultaneously even if they require different ocaml versions, or different versions of merlin.

How: All this diff does is wrap all the calls like this
- `command-exec ocamlmerlin`
- `command-exec refmt --print-width 80`

And only if the `command-exec` file is present. Projects without that file should not be affected.

Note: We haven't yet began to emit `command-exec` from `esy`, but we will very soon. We wanted to get this out there so that it will be ready for people. I've tested it locally.

Note: The `command-exec` wrapper is not `esy` specific and any package/project manager out there could emit this file. We will also be adding support in Vim and Nuclide/Atom.

I tested on a project with a `command-exec`, and another project without, just to make sure everything still works.

There are `command-exec.bat` hooks in place for `win32` which we can easily make "do the right thing" if the user happens to be using WSL - (it will wrap the commands in the bash call as well which removes one more step from the WSL setup). We can also make sure that on `win32` without WSL, the `command-exec.bat` hooks also do the right thing when we support full windows.