### PR TITLE
APIs For Introspecting Reason/OCaml LSP Environments

### DIFF
--- a/src/bin/server/command/getAvailableLibraries.ts
+++ b/src/bin/server/command/getAvailableLibraries.ts
@@ -1,0 +1,22 @@
+import * as server from "vscode-languageserver";
+import * as processes from "../processes";
+import Session from "../session";
+
+export default async function(
+  session: Session,
+  _: server.TextDocumentIdentifier,
+): Promise<string[]> {
+  const ocamlfind = new processes.Ocamlfind(session).process;
+  ocamlfind.stdin.end();
+  const otxt = await new Promise<string>((resolve, reject) => {
+    let buffer = "";
+    ocamlfind.stdout.on("error", (error: Error) => reject(error));
+    ocamlfind.stdout.on(
+      "data",
+      (data: Buffer | string) => (buffer += data.toString()),
+    );
+    ocamlfind.stdout.on("end", () => resolve(buffer));
+  });
+  ocamlfind.unref();
+  return /^\s*$/.test(otxt) ? [] : otxt.trim().split("\n");
+}

--- a/src/bin/server/command/getProjectEnv.ts
+++ b/src/bin/server/command/getProjectEnv.ts
@@ -1,0 +1,22 @@
+import * as server from "vscode-languageserver";
+import * as processes from "../processes";
+import Session from "../session";
+
+export default async function(
+  session: Session,
+  _: server.TextDocumentIdentifier,
+): Promise<string[]> {
+  const env = new processes.Env(session).process;
+  env.stdin.end();
+  const otxt = await new Promise<string>((resolve, reject) => {
+    let buffer = "";
+    env.stdout.on("error", (error: Error) => reject(error));
+    env.stdout.on(
+      "data",
+      (data: Buffer | string) => (buffer += data.toString()),
+    );
+    env.stdout.on("end", () => resolve(buffer));
+  });
+  env.unref();
+  return /^\s*$/.test(otxt) ? [] : otxt.trim().split("\n");
+}

--- a/src/bin/server/command/index.ts
+++ b/src/bin/server/command/index.ts
@@ -1,9 +1,12 @@
-import getDocumentation from "./getDocumentation";
 import * as getFormatted from "./getFormatted";
+
+import getAvailableLibraries from "./getAvailableLibraries";
+import getDocumentation from "./getDocumentation";
 import getMerlinFiles from "./getMerlinFiles";
 import getModules from "./getModules";
 import getOccurrences from "./getOccurrences";
 import getPrefix from "./getPrefix";
+import getProjectEnv from "./getProjectEnv";
 import getText from "./getText";
 import getTextDocument from "./getTextDocument";
 import getType from "./getType";
@@ -11,15 +14,17 @@ import getWordAtPosition from "./getWordAtPosition";
 import restartMerlin from "./restartMerlin";
 
 export {
-  restartMerlin,
+  getAvailableLibraries,
   getDocumentation,
   getFormatted,
   getMerlinFiles,
   getModules,
   getOccurrences,
   getPrefix,
+  getProjectEnv,
   getText,
   getTextDocument,
   getType,
   getWordAtPosition,
+  restartMerlin,
 };

--- a/src/bin/server/feature/didChangeWatchedFiles.ts
+++ b/src/bin/server/feature/didChangeWatchedFiles.ts
@@ -9,8 +9,7 @@ export default function(
     for (const id of event.changes) {
       if (/\.(ml|re)$/.test(id.uri)) return session.indexer.refreshSymbols(id);
       if (/\.(merlin)$/.test(id.uri)) return command.restartMerlin(session);
-      if (/(command-exec)$/.test(id.uri))
-        return command.restartMerlin(session);
+      if (/(command-exec)$/.test(id.uri)) return command.restartMerlin(session);
       if (/(command-exec.cmd)$/.test(id.uri))
         return command.restartMerlin(session);
     }

--- a/src/bin/server/index.ts
+++ b/src/bin/server/index.ts
@@ -34,6 +34,8 @@ session.connection.onWorkspaceSymbol(feature.workspaceSymbol(session));
 // vscode-reasonml features
 session.connection.onRequest(remote.server.giveCaseAnalysis, request.giveCaseAnalysis(session));
 session.connection.onRequest(remote.server.giveMerlinFiles, request.giveMerlinFiles(session));
+session.connection.onRequest(remote.server.giveAvailableLibraries, request.giveAvailableLibraries(session));
+session.connection.onRequest(remote.server.giveProjectEnv, request.giveProjectEnv(session));
 session.connection.onRequest(remote.server.giveFormatted, request.giveFormatted(session));
 
 session.listen();

--- a/src/bin/server/processes/env.ts
+++ b/src/bin/server/processes/env.ts
@@ -1,0 +1,10 @@
+import { ChildProcess } from "child_process";
+import Session from "../session";
+
+export default class Env {
+  public readonly process: ChildProcess;
+  constructor(session: Session) {
+    const command = session.settings.reason.path.env;
+    this.process = session.environment.spawn(command, []);
+  }
+}

--- a/src/bin/server/processes/esy.ts
+++ b/src/bin/server/processes/esy.ts
@@ -1,0 +1,30 @@
+import Session from "../session";
+
+export default class Esy {
+  constructor(private readonly session: Session) {}
+
+  public run(): Promise<string> {
+    let buffer = "";
+    return new Promise(resolve => {
+      const command = this.session.settings.reason.path.esy;
+      const args = ["build"];
+      const process = this.session.environment.spawn(command, args);
+
+      process.on("error", (error: Error & { code: string }) => {
+        if (error.code === "ENOENT") {
+          const msg = `Perhapse we cannot find esy binary at "${command}".`;
+          this.session.connection.window.showWarningMessage(msg);
+          this.session.connection.window.showWarningMessage(
+            `Double check your path or try configuring "reason.path.esy" under "User Settings". Do you need to "npm install -g esy"? Alternatively, disable "esy" in "reason.diagnostics.tools"`,
+          );
+        }
+        resolve("");
+      });
+      process.stdout.on(
+        "data",
+        (data: Buffer | string) => (buffer += data.toString()),
+      );
+      process.stdout.on("end", () => resolve(buffer));
+    });
+  }
+}

--- a/src/bin/server/processes/index.ts
+++ b/src/bin/server/processes/index.ts
@@ -1,6 +1,9 @@
 import BuckleScript from "./bucklescript";
+import Env from "./env";
+import Esy from "./esy";
 import Merlin from "./merlin";
+import Ocamlfind from "./ocamlfind";
 import OcpIndent from "./ocpIndent";
 import ReFMT from "./refmt";
 
-export { Merlin, OcpIndent, ReFMT, BuckleScript };
+export { Ocamlfind, Esy, Env, Merlin, OcpIndent, ReFMT, BuckleScript };

--- a/src/bin/server/processes/ocamlfind.ts
+++ b/src/bin/server/processes/ocamlfind.ts
@@ -1,0 +1,11 @@
+import { ChildProcess } from "child_process";
+import Session from "../session";
+
+export default class Ocamlfind {
+  public readonly process: ChildProcess;
+  constructor(session: Session, argsOpt?: string[]) {
+    const command = session.settings.reason.path.ocamlfind;
+    const args = argsOpt || ["list"];
+    this.process = session.environment.spawn(command, args);
+  }
+}

--- a/src/bin/server/request/giveAvailableLibraries.ts
+++ b/src/bin/server/request/giveAvailableLibraries.ts
@@ -1,0 +1,10 @@
+import * as server from "vscode-languageserver";
+import { types } from "../../../lib";
+import * as command from "../command";
+import Session from "../session";
+
+export default function(
+  session: Session,
+): server.RequestHandler<types.TextDocumentIdentifier, string[], void> {
+  return event => command.getAvailableLibraries(session, event);
+}

--- a/src/bin/server/request/giveProjectEnv.ts
+++ b/src/bin/server/request/giveProjectEnv.ts
@@ -1,0 +1,10 @@
+import * as server from "vscode-languageserver";
+import { types } from "../../../lib";
+import * as command from "../command";
+import Session from "../session";
+
+export default function(
+  session: Session,
+): server.RequestHandler<types.TextDocumentIdentifier, string[], void> {
+  return event => command.getProjectEnv(session, event);
+}

--- a/src/bin/server/request/index.ts
+++ b/src/bin/server/request/index.ts
@@ -1,5 +1,13 @@
+import giveAvailableLibraries from "./giveAvailableLibraries";
 import giveCaseAnalysis from "./giveCaseAnalysis";
 import giveFormatted from "./giveFormatted";
 import giveMerlinFiles from "./giveMerlinFiles";
+import giveProjectEnv from "./giveProjectEnv";
 
-export { giveCaseAnalysis, giveMerlinFiles, giveFormatted };
+export {
+  giveCaseAnalysis,
+  giveMerlinFiles,
+  giveFormatted,
+  giveAvailableLibraries,
+  giveProjectEnv,
+};

--- a/src/bin/server/session/environment.ts
+++ b/src/bin/server/session/environment.ts
@@ -78,9 +78,7 @@ export default class Environment implements server.Disposable {
           "_esy",
           "build",
           "bin",
-          process.platform === "win32"
-            ? "command-exec.bat"
-            : "command-exec",
+          process.platform === "win32" ? "command-exec.bat" : "command-exec",
         );
   }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,10 +15,12 @@ export interface ISettings {
     };
     diagnostics: {
       merlinPerfLogging: boolean;
-      tools: Array<"merlin" | "bsb">;
+      tools: Array<"merlin" | "bsb" | "esy">;
     };
     path: {
       bsb: string;
+      env: string;
+      esy: string;
       ocamlfind: string;
       ocamlmerlin: string;
       opam: string;
@@ -48,6 +50,8 @@ export namespace ISettings {
       },
       path: {
         bsb: "bsb",
+        env: "env",
+        esy: "esy",
         ocamlfind: "ocamlfind",
         ocamlmerlin: "ocamlmerlin",
         opam: "opam",

--- a/src/lib/remote/server.ts
+++ b/src/lib/remote/server.ts
@@ -18,6 +18,20 @@ export const giveMerlinFiles = new RequestType<
   void
 >("reason.server.giveMerlinFiles");
 
+export const giveAvailableLibraries = new RequestType<
+  types.TextDocumentIdentifier,
+  string[],
+  void,
+  void
+>("reason.server.giveAvailableLibraries");
+
+export const giveProjectEnv = new RequestType<
+  types.TextDocumentIdentifier,
+  string[],
+  void,
+  void
+>("reason.server.giveProjectEnv");
+
 export const giveFormatted = new RequestType<
   types.IUnformattedTextDocument,
   null | string,


### PR DESCRIPTION
**This diff implement Two New Language Server Features For Exploring IDE Environment.**

One common issue with the vscode Reason plugin is that people are running it in an environment that consists of some hybrid of Opam, npm etc without fully understanding their dev time dependencies or what LSP "sees". This makes it difficult to help the Discord community.

I've added a server API to explore the user's environment, with an autocomplete window to search for various keywords such as `"merlin_version"`, or `PATH`.  When hitting enter on an entry, it will open the variable in a new editing buffer. The user may also choose `Show Entire Environment` which will open up the environment that the language server sees in a new windows, so that users may copy/paste it into the Discord channel so that we can help debug their setup. (Warning: make sure you don't have any sensitive data in your environment before sharing publicly).

Another issue is that when building native libraries, such as the Reason parser itself, the build is misconfigured or tries to depend on libraries that aren't actually provided by the package dependencies.  Each ocaml package contains multiple possible library names - it's not a 1-1 mapping, so it can be confusing to people new to the ecosystem.  Here, I'm also adding a feature to display a popup list of ocaml *library* dependencies provided by the project dependencies. Because of [my previous PR](https://github.com/freebroccolo/ocaml-language-server/pull/44) all of these introspections are now project specific. It will fall back to global introspection if you don't have well-isolated projects.