### PR TITLE
Swap deepmerge order and fix merge

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -72,7 +72,7 @@ export namespace ISettings {
   };
 
   export function withDefaults(overrides: ISettings | undefined | null): ISettings {
-    return deepmerge(overrides || {}, defaults);
+    return deepmerge(defaults, { reason: overrides ? overrides.reason || overrides : {} });
   }
 }
 


### PR DESCRIPTION
Hello.

Was bumping into this issue in WSL: https://github.com/reasonml-editor/vscode-reasonml/issues/186 where Merlin wouldn't work in VSCode anymore. The problem seems to be two-fold:
1. The `deepmerge` params are in the wrong order. According to deepmerge: 
> merge(x, y, [options])
Merge two objects x and y deeply, returning a new merged object with the elements from both x and y.
If an element at the same key is present for both x and y, the value from y will appear in the result.

In lib/index.js:
```js
function withDefaults(overrides) {
  return deepmerge(overrides || {}, ISettings.defaults);
}
```
So the defaults always win.

2. The `overrides` object doesn't have the `reason` top-level key so the merged data will consist of both objects. with the defaults set in {reason: {...stuff}} but my overridden settings in {...stuff}, like so:
```js
{ codelens: { unicode: true, enabled: true },
  debounce: { linter: 500 },
  diagnostics: { tools: [ 'bsb', 'merlin' ] },
  format: { width: 100 },
  path: 
   { bsb: 'bash -ic bsb',
     ocamlfind: 'bash -ic ocamlfind',
     esy: 'esy',
     env: 'env',
     ocamlmerlin: 'bash -ic ocamlmerlin',
     opam: 'bash -ic opam',
     rebuild: 'bash -ic rebuild',
     refmt: 'bash -ic refmt',
     refmterr: 'bash -ic refmterr',
     rtop: 'bash -ic rtop' },
  server: { languages: [ 'ocaml', 'reason' ] },
  reason: 
   { codelens: { enabled: true, unicode: true },
     debounce: { linter: 500 },
     diagnostics: { merlinPerfLogging: false, tools: [Object] },
     format: { width: null },
     path: 
      { bsb: 'bsb',
        env: 'env',
        esy: 'esy',
        ocamlfind: 'ocamlfind',
        ocamlmerlin: 'ocamlmerlin',
        opam: 'opam',
        rebuild: 'rebuild',
        refmt: 'refmt',
        refmterr: 'refmterr',
        rtop: 'rtop' },
     server: { languages: [Object] } } }
```

I have not worked with the code of this extension (or any other VScode extension) at all before so I'm unaware if this `reason` key in the overrides object used to exist?