### PR TITLE
Ewen/add merlin args and local switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,26 +23,34 @@
     "prebuild": "npm run build:pegjs:ocamldoc && npm run format && npm run lint",
     "watch": "npm run prebuild && tsc -watch -p ./",
     "build": "tsc -p ./",
-    "build:pegjs:ocamldoc":
-      "shx mkdir -p bin/server/parser/ocamldoc && pegjs -o bin/server/parser/ocamldoc/grammar.js src/bin/server/parser/ocamldoc/grammar.pegjs",
+    "build:pegjs:ocamldoc": "shx mkdir -p bin/server/parser/ocamldoc && pegjs -o bin/server/parser/ocamldoc/grammar.js src/bin/server/parser/ocamldoc/grammar.pegjs",
     "format": "./node_modules/.bin/prettier --write \"src/**/*.ts\"",
     "lint": "tslint --project tsconfig.json",
     "prepare": "npm run build",
     "test": "jest"
   },
   "jest": {
-    "moduleFileExtensions": ["ts", "tsx", "js"],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
     "transform": {
       "^.+\\.(ts|tsx)$": "ts-jest"
     },
-    "testMatch": ["**/__tests__/*.(ts|tsx|js)"]
+    "testMatch": [
+      "**/__tests__/*.(ts|tsx|js)"
+    ]
   },
   "main": "./lib/index.js",
   "typings": "./lib/index",
   "bin": {
     "ocaml-language-server": "./bin/server/index.js"
   },
-  "files": ["bin", "lib"],
+  "files": [
+    "bin",
+    "lib"
+  ],
   "devDependencies": {
     "@types/async": "2.0.48",
     "@types/deepmerge": "2.1.0",

--- a/src/bin/server/lifecycle/initialize.ts
+++ b/src/bin/server/lifecycle/initialize.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import * as LSP from "vscode-languageserver-protocol";
 import { ISettings } from "../../../lib";
 import capabilities from "../capabilities";
@@ -10,6 +11,13 @@ export default function(
     const overrides: typeof ISettings.defaults.reason | undefined | null = event.initializationOptions;
     (session.initConf as any) = event;
     session.settings.reason = ISettings.withDefaults(overrides);
+    const opamCmd = execSync(`command -v ${session.settings.reason.path.opam} 2>&1 || echo >&2 ""`).toString();
+    if (opamCmd === "") {
+      session.hasOpam = undefined;
+    } else {
+      const version = execSync(`${session.settings.reason.path.opam} --version`).toString();
+      session.hasOpam = version.substring(0, 1);
+    }
     await session.initialize();
     return { capabilities };
   };

--- a/src/bin/server/processes/merlin.ts
+++ b/src/bin/server/processes/merlin.ts
@@ -23,7 +23,13 @@ export default class Merlin implements LSP.Disposable {
     const cwd = this.session.initConf.rootUri || this.session.initConf.rootPath;
     const options = cwd ? { cwd: URI.parse(cwd).fsPath } : {};
 
-    (this.process as any) = this.session.environment.spawn(ocamlmerlin, [], options);
+    const [cmd, args] = this.session.makeOpamCmd(ocamlmerlin);
+
+    (this.process as any) = this.session.environment.spawn(
+      cmd,
+      args.concat(this.session.settings.reason.path.ocamlmerlinArgs),
+      options,
+    );
 
     // this.process.on("exit", (code, signal) => {
     //   this.session.connection.console.log(JSON.stringify({ code, signal }));

--- a/src/bin/server/processes/ocamlfind.ts
+++ b/src/bin/server/processes/ocamlfind.ts
@@ -6,6 +6,7 @@ export default class Ocamlfind {
   constructor(session: Session, argsOpt?: string[]) {
     const command = session.settings.reason.path.ocamlfind;
     const args = argsOpt || ["list"];
-    this.process = session.environment.spawn(command, args);
+    const [cmd, cmdArgs] = session.makeOpamCmd(command);
+    this.process = session.environment.spawn(cmd, cmdArgs.concat(args));
   }
 }

--- a/src/bin/server/processes/ocpIndent.ts
+++ b/src/bin/server/processes/ocpIndent.ts
@@ -5,7 +5,8 @@ export default class OcpIndent {
   public readonly process: ChildProcess;
   constructor(session: Session, args: string[] = []) {
     const command = session.settings.reason.path.ocpindent;
-    this.process = session.environment.spawn(command, args);
+    const [cmd, cmdArgs] = session.makeOpamCmd(command);
+    this.process = session.environment.spawn(cmd, cmdArgs.concat(args));
     this.process.on("error", error => session.error(`Error formatting file: ${error}`));
   }
 }

--- a/src/bin/server/processes/ocpIndent.ts
+++ b/src/bin/server/processes/ocpIndent.ts
@@ -7,6 +7,15 @@ export default class OcpIndent {
     const command = session.settings.reason.path.ocpindent;
     const [cmd, cmdArgs] = session.makeOpamCmd(command);
     this.process = session.environment.spawn(cmd, cmdArgs.concat(args));
-    this.process.on("error", error => session.error(`Error formatting file: ${error}`));
+
+    if (session.hasOpam) {
+      this.process.on("exit", code => {
+        if (code !== 0) {
+          session.error(`Opam error formatting file with code: ${code}`);
+        }
+      });
+    } else {
+      this.process.on("error", error => session.error(`Error formatting file: ${error}`));
+    }
   }
 }

--- a/src/bin/server/processes/refmt.ts
+++ b/src/bin/server/processes/refmt.ts
@@ -11,7 +11,8 @@ export default class ReFMT {
     const width = session.settings.reason.format.width;
     const widthArg = width === null ? [] : ["--print-width", `${width}`];
 
+    const [cmd, cmdArgs] = session.makeOpamCmd(command);
     const args = argsOpt || ["--parse", "re", "--print", "re", "--interface", `${/\.rei$/.test(uri)}`].concat(widthArg);
-    this.process = session.environment.spawn(command, args);
+    this.process = session.environment.spawn(cmd, cmdArgs.concat(args));
   }
 }

--- a/src/bin/server/session/index.ts
+++ b/src/bin/server/session/index.ts
@@ -19,6 +19,7 @@ export default class Session implements LSP.Disposable {
   };
   public readonly connection: server.IConnection = server.createConnection();
   public readonly environment: Environment;
+  public hasOpam: string | undefined;
   public readonly indexer: Indexer;
   public readonly initConf: LSP.InitializeParams;
   public readonly merlin: Merlin;
@@ -66,6 +67,18 @@ export default class Session implements LSP.Disposable {
 
   public log(data: any): void {
     this.connection.console.log(JSON.stringify(data, null, 2));
+  }
+
+  public makeOpamCmd(cmd: string): [string, string[]] {
+    if (this.hasOpam) {
+      if (this.hasOpam === "1") {
+        return [this.settings.reason.path.opam, ["env", "exec", "--", cmd]];
+      } else {
+        return [this.settings.reason.path.opam, ["exec", "--", cmd]];
+      }
+    } else {
+      return [cmd, []];
+    }
   }
 
   public async onDidChangeConfiguration({ settings }: LSP.DidChangeConfigurationParams): Promise<void> {

--- a/src/bin/server/session/synchronizer.ts
+++ b/src/bin/server/session/synchronizer.ts
@@ -48,7 +48,10 @@ export default class Synchronizer implements LSP.Disposable {
     languageId: string,
     content: string,
   ): Promise<void> {
-    this.documents.set(document.uri, LSP.TextDocument.create(document.uri, languageId, document.version, content));
+    this.documents.set(
+      document.uri,
+      LSP.TextDocument.create(document.uri, languageId, document.version ? document.version : 0, content),
+    );
     const request = merlin.Sync.tell("start", "end", content);
     await this.session.merlin.sync(request, document);
   }
@@ -64,7 +67,12 @@ export default class Synchronizer implements LSP.Disposable {
     if (null != newContent) {
       this.documents.set(
         newDocument.uri,
-        LSP.TextDocument.create(oldDocument.uri, oldDocument.languageId, newDocument.version, newContent),
+        LSP.TextDocument.create(
+          oldDocument.uri,
+          oldDocument.languageId,
+          newDocument.version ? newDocument.version : 0,
+          newContent,
+        ),
       );
     }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -22,6 +22,7 @@ export interface ISettings {
       esy: string;
       ocamlfind: string;
       ocamlmerlin: string;
+      ocamlmerlinArgs: string[];
       ocpindent: string;
       opam: string;
       rebuild: string;
@@ -60,6 +61,7 @@ export namespace ISettings {
         esy: "esy",
         ocamlfind: "ocamlfind",
         ocamlmerlin: "ocamlmerlin",
+        ocamlmerlinArgs: [],
         ocpindent: "ocp-indent",
         opam: "opam",
         rebuild: "rebuild",


### PR DESCRIPTION
This PR introduces two potential proposed functionalities, which have been tested:

1 - allow merlin arguments via an environment variable `reason.ocaml.ocamlmerlinArgs`

2- sync local opam switches to the switch corresponding to the directory of the workspace. By checking for opam and then executing `opam exec --` or `opam env exec --` depending on the opam version, the commands for `merlin`, `ocp-indent`,`ocamlfind` and `refmt` can be associated to a local switch thus behaving as they would if run from the command line in the same directory. This is also true for any readers which might be called by merlin via the `reason.path.ocamlmerlinArgs` environment variable.