### PR TITLE
[WIP] Add ocamlformat support

### DIFF
--- a/src/bin/server/feature/documentFormatting.ts
+++ b/src/bin/server/feature/documentFormatting.ts
@@ -14,7 +14,12 @@ export default function(session: Session): LSP.RequestHandler<LSP.DocumentFormat
       result.getText(),
     );
     let otxt: null | string = null;
-    if (document.languageId === "ocaml") otxt = await command.getFormatted.ocpIndent(session, document);
+    if (document.languageId === "ocaml") {
+      // FIXME: This needs a better name.
+      const tool = session.settings.reason.format.ocamltool;
+      if (tool === "ocamlformat") otxt = await command.getFormatted.ocamlformat(session, document);
+      else if (tool === "ocp-indent") otxt = await command.getFormatted.ocpIndent(session, document);
+    }
     if (document.languageId === "reason") otxt = await command.getFormatted.refmt(session, document);
     if (null == otxt || "" === otxt) return [];
     const edits: LSP.TextEdit[] = [];

--- a/src/bin/server/processes/index.ts
+++ b/src/bin/server/processes/index.ts
@@ -3,7 +3,8 @@ import Env from "./env";
 import Esy from "./esy";
 import Merlin from "./merlin";
 import Ocamlfind from "./ocamlfind";
+import Ocamlformat from "./ocamlformat";
 import OcpIndent from "./ocpIndent";
 import ReFMT from "./refmt";
 
-export { Ocamlfind, Esy, Env, Merlin, OcpIndent, ReFMT, BuckleScript };
+export { Ocamlfind, Esy, Env, Merlin, Ocamlformat, OcpIndent, ReFMT, BuckleScript };

--- a/src/bin/server/processes/ocamlformat.ts
+++ b/src/bin/server/processes/ocamlformat.ts
@@ -1,0 +1,11 @@
+import { ChildProcess } from "child_process";
+import Session from "../session";
+
+export default class Ocamlformat {
+  public readonly process: ChildProcess;
+  constructor(session: Session, args: string[] = []) {
+    const command = session.settings.reason.path.ocamlformat;
+    this.process = session.environment.spawn(command, args);
+    this.process.on("error", error => session.error(`Error formatting file: ${error}`));
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -21,6 +21,7 @@ export interface ISettings {
       env: string;
       esy: string;
       ocamlfind: string;
+      ocamlformat: string;
       ocamlmerlin: string;
       ocpindent: string;
       opam: string;
@@ -30,6 +31,8 @@ export interface ISettings {
       rtop: string;
     };
     format: {
+      // FIXME: This needs a better name.
+      ocamltool: "ocamlformat" | "ocp-indent";
       width: number | null;
     };
     server: {
@@ -52,6 +55,7 @@ export namespace ISettings {
         tools: ["merlin"],
       },
       format: {
+        ocamltool: "ocamlformat",
         width: null,
       },
       path: {
@@ -59,6 +63,7 @@ export namespace ISettings {
         env: "env",
         esy: "esy",
         ocamlfind: "ocamlfind",
+        ocamlformat: "ocamlformat",
         ocamlmerlin: "ocamlmerlin",
         ocpindent: "ocp-indent",
         opam: "opam",


### PR DESCRIPTION
So I decided to take a gander and knock out this (and reasonml-editor/vscode-reasonml#184, by extension); but I ran into some problems.

Would love if you could take a look and catch where I went wrong, @freebroccolo! Everything "seems to work", but the code doesn't actually get run thru `ocamlformat`, as far as I can tell. No errors anywhere. (This is my first contribution to anything VSCode-related, so I wasn't very sure how to go about debugging the dang thing, though.)

Also, the configuration path will need some bikeshedding. `reason.format.tool` conflicts with a possible configurable replacement for `refmt` in the future, but my temporary hack, `reason.format.ocamltool`, is hella ugly.

Personally, I think we should split out into two root objects — `ocaml.format.tool` would then be possible — but that may be too large an effort. `¯\_(ツ)_/¯`

(This closes #50.)